### PR TITLE
Implement `mcpcli ping` command (issue #14)

### DIFF
--- a/.claude/skills/mcpcli.md
+++ b/.claude/skills/mcpcli.md
@@ -87,6 +87,8 @@ mcpcli deauth <server>      # remove stored auth
 | `mcpcli auth <server> -s`              | Check token status and TTL        |
 | `mcpcli auth <server> -r`              | Force token refresh               |
 | `mcpcli deauth <server>`               | Remove stored authentication      |
+| `mcpcli ping`                          | Check connectivity to all servers |
+| `mcpcli ping <server> [server2...]`    | Check specific server(s)          |
 | `mcpcli add <name> --command <cmd>`    | Add a stdio MCP server            |
 | `mcpcli add <name> --url <url>`        | Add an HTTP MCP server            |
 | `mcpcli remove <name>`                 | Remove an MCP server              |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ mcpcli search -q "manage pull requests"
 | `mcpcli add <name> --command <cmd>`  | Add a stdio MCP server to your config        |
 | `mcpcli add <name> --url <url>`      | Add an HTTP MCP server to your config        |
 | `mcpcli remove <name>`               | Remove an MCP server from your config        |
+| `mcpcli ping`                        | Check connectivity to all configured servers |
+| `mcpcli ping <server> [server2...]`  | Check connectivity to specific server(s)     |
 | `mcpcli skill install --claude`      | Install the mcpcli skill for Claude Code     |
 
 ## Options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { registerIndexCommand } from "./commands/index.ts";
 import { registerAddCommand } from "./commands/add.ts";
 import { registerRemoveCommand } from "./commands/remove.ts";
 import { registerSkillCommand } from "./commands/skill.ts";
+import { registerPingCommand } from "./commands/ping.ts";
 
 declare const BUILD_VERSION: string | undefined;
 
@@ -35,5 +36,6 @@ registerIndexCommand(program);
 registerAddCommand(program);
 registerRemoveCommand(program);
 registerSkillCommand(program);
+registerPingCommand(program);
 
 program.parse();

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,0 +1,69 @@
+import { green, red } from "ansis";
+import type { Command } from "commander";
+import { getContext } from "../context.ts";
+import { formatError } from "../output/formatter.ts";
+import { logger } from "../output/logger.ts";
+
+interface PingResult {
+  server: string;
+  success: boolean;
+  latencyMs?: number;
+  error?: string;
+}
+
+export function registerPingCommand(program: Command) {
+  program
+    .command("ping [servers...]")
+    .description("Check connectivity to MCP servers")
+    .action(async (servers: string[]) => {
+      const { manager, formatOptions } = await getContext(program);
+
+      const targetServers = servers.length > 0 ? servers : manager.getServerNames();
+
+      if (targetServers.length === 0) {
+        console.error(formatError("No servers configured", formatOptions));
+        await manager.close();
+        process.exit(1);
+      }
+
+      const spinner = logger.startSpinner(
+        `Pinging ${targetServers.length} server(s)...`,
+        formatOptions,
+      );
+
+      const results: PingResult[] = [];
+
+      try {
+        await Promise.all(
+          targetServers.map(async (serverName) => {
+            const start = Date.now();
+            try {
+              await manager.getClient(serverName);
+              results.push({ server: serverName, success: true, latencyMs: Date.now() - start });
+            } catch (err) {
+              results.push({ server: serverName, success: false, error: String(err) });
+            }
+          }),
+        );
+
+        spinner.stop();
+
+        if (formatOptions.json) {
+          console.log(JSON.stringify(results, null, 2));
+        } else {
+          for (const r of results) {
+            if (r.success) {
+              console.log(`${green("✔")} ${r.server} connected (${r.latencyMs}ms)`);
+            } else {
+              console.log(`${red("✖")} ${r.server} failed: ${r.error}`);
+            }
+          }
+        }
+      } finally {
+        await manager.close();
+      }
+
+      const anyFailed = results.some((r) => !r.success);
+      if (anyFailed) process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Add a new `ping` command to verify MCP server connectivity. This addresses issue #14 by providing a lightweight way to check server status without running full operations like `list` or `exec`.

**Features:**
- Ping all configured servers or specific servers by name
- Measures latency per server with parallel execution
- Human-readable output with colored status indicators (✔ / ✖)
- JSON output mode for scripting and CI/CD integration
- Proper exit codes (0 on success, 1 on failure) for shell scripting

**Version bump:** 0.5.1 → 0.5.2 (patch)

## Test plan

- ✅ All 144 existing tests pass
- ✅ Code formatted with prettier
- ✅ Manual testing: `bun run dev ping`