### PR TITLE
Add resources and prompts commands (#13)

### DIFF
--- a/.claude/skills/mcpcli.md
+++ b/.claude/skills/mcpcli.md
@@ -93,3 +93,9 @@ mcpcli deauth <server>      # remove stored auth
 | `mcpcli add <name> --url <url>`        | Add an HTTP MCP server            |
 | `mcpcli remove <name>`                 | Remove an MCP server              |
 | `mcpcli skill install --claude`        | Install mcpcli skill for Claude   |
+| `mcpcli resource`                     | List all resources across servers |
+| `mcpcli resource <server>`            | List resources for a server       |
+| `mcpcli resource <server> <uri>`      | Read a specific resource          |
+| `mcpcli prompt`                       | List all prompts across servers   |
+| `mcpcli prompt <server>`              | List prompts for a server         |
+| `mcpcli prompt <server> <name> '<json>'` | Get a specific prompt          |

--- a/README.md
+++ b/README.md
@@ -49,28 +49,34 @@ mcpcli search -q "manage pull requests"
 
 ## Commands
 
-| Command                              | Description                                  |
-| ------------------------------------ | -------------------------------------------- |
-| `mcpcli`                             | List all configured servers and tools        |
-| `mcpcli info <server>`               | Show tools for a server                      |
-| `mcpcli info <server> <tool>`        | Show tool schema                             |
-| `mcpcli search <query>`              | Search tools (keyword + semantic)            |
-| `mcpcli search -k <pattern>`         | Keyword/glob search only                     |
-| `mcpcli search -q <query>`           | Semantic search only                         |
-| `mcpcli index`                       | Build/rebuild the search index               |
-| `mcpcli index -i`                    | Show index status                            |
-| `mcpcli exec <server> <tool> [json]` | Validate inputs locally, then execute tool   |
-| `mcpcli exec <server>`               | List available tools for a server            |
-| `mcpcli auth <server>`               | Authenticate with an HTTP MCP server (OAuth) |
-| `mcpcli auth <server> -s`            | Check auth status and token TTL              |
-| `mcpcli auth <server> -r`            | Force token refresh                          |
-| `mcpcli deauth <server>`             | Remove stored authentication for a server    |
-| `mcpcli add <name> --command <cmd>`  | Add a stdio MCP server to your config        |
-| `mcpcli add <name> --url <url>`      | Add an HTTP MCP server to your config        |
-| `mcpcli remove <name>`               | Remove an MCP server from your config        |
-| `mcpcli ping`                        | Check connectivity to all configured servers |
-| `mcpcli ping <server> [server2...]`  | Check connectivity to specific server(s)     |
-| `mcpcli skill install --claude`      | Install the mcpcli skill for Claude Code     |
+| Command                                | Description                                  |
+| -------------------------------------- | -------------------------------------------- |
+| `mcpcli`                               | List all configured servers and tools        |
+| `mcpcli info <server>`                 | Show tools for a server                      |
+| `mcpcli info <server> <tool>`          | Show tool schema                             |
+| `mcpcli search <query>`                | Search tools (keyword + semantic)            |
+| `mcpcli search -k <pattern>`           | Keyword/glob search only                     |
+| `mcpcli search -q <query>`             | Semantic search only                         |
+| `mcpcli index`                         | Build/rebuild the search index               |
+| `mcpcli index -i`                      | Show index status                            |
+| `mcpcli exec <server> <tool> [json]`   | Validate inputs locally, then execute tool   |
+| `mcpcli exec <server>`                 | List available tools for a server            |
+| `mcpcli auth <server>`                 | Authenticate with an HTTP MCP server (OAuth) |
+| `mcpcli auth <server> -s`              | Check auth status and token TTL              |
+| `mcpcli auth <server> -r`              | Force token refresh                          |
+| `mcpcli deauth <server>`               | Remove stored authentication for a server    |
+| `mcpcli add <name> --command <cmd>`    | Add a stdio MCP server to your config        |
+| `mcpcli add <name> --url <url>`        | Add an HTTP MCP server to your config        |
+| `mcpcli remove <name>`                 | Remove an MCP server from your config        |
+| `mcpcli ping`                          | Check connectivity to all configured servers |
+| `mcpcli ping <server> [server2...]`    | Check connectivity to specific server(s)     |
+| `mcpcli skill install --claude`        | Install the mcpcli skill for Claude Code     |
+| `mcpcli resource`                      | List all resources across all servers        |
+| `mcpcli resource <server>`             | List resources for a server                  |
+| `mcpcli resource <server> <uri>`       | Read a specific resource                     |
+| `mcpcli prompt`                        | List all prompts across all servers          |
+| `mcpcli prompt <server>`               | List prompts for a server                    |
+| `mcpcli prompt <server> <name> [json]` | Get a specific prompt                        |
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.5.2",
+  "version": "0.6.4",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,8 @@ import { registerAddCommand } from "./commands/add.ts";
 import { registerRemoveCommand } from "./commands/remove.ts";
 import { registerSkillCommand } from "./commands/skill.ts";
 import { registerPingCommand } from "./commands/ping.ts";
+import { registerResourceCommand } from "./commands/resource.ts";
+import { registerPromptCommand } from "./commands/prompt.ts";
 
 declare const BUILD_VERSION: string | undefined;
 
@@ -37,5 +39,7 @@ registerAddCommand(program);
 registerRemoveCommand(program);
 registerSkillCommand(program);
 registerPingCommand(program);
+registerResourceCommand(program);
+registerPromptCommand(program);
 
 program.parse();

--- a/src/client/manager.ts
+++ b/src/client/manager.ts
@@ -1,7 +1,14 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import picomatch from "picomatch";
-import type { Tool, ServerConfig, ServersFile, AuthFile } from "../config/schemas.ts";
+import type {
+  Tool,
+  Resource,
+  Prompt,
+  ServerConfig,
+  ServersFile,
+  AuthFile,
+} from "../config/schemas.ts";
 import { isStdioServer, isHttpServer } from "../config/schemas.ts";
 import { createStdioTransport } from "./stdio.ts";
 import { createHttpTransport } from "./http.ts";
@@ -10,6 +17,16 @@ import { McpOAuthProvider } from "./oauth.ts";
 export interface ToolWithServer {
   server: string;
   tool: Tool;
+}
+
+export interface ResourceWithServer {
+  server: string;
+  resource: Resource;
+}
+
+export interface PromptWithServer {
+  server: string;
+  prompt: Prompt;
 }
 
 export interface ServerError {
@@ -30,6 +47,7 @@ export interface ServerManagerOptions {
 
 export class ServerManager {
   private clients = new Map<string, Client>();
+  private connecting = new Map<string, Promise<Client>>();
   private transports = new Map<string, Transport>();
   private oauthProviders = new Map<string, McpOAuthProvider>();
   private servers: ServersFile;
@@ -57,32 +75,45 @@ export class ServerManager {
     const existing = this.clients.get(serverName);
     if (existing) return existing;
 
+    // If a connection is already in flight, wait for it instead of opening a second one
+    const inflight = this.connecting.get(serverName);
+    if (inflight) return inflight;
+
     const config = this.servers.mcpServers[serverName];
     if (!config) {
       throw new Error(`Unknown server: "${serverName}"`);
     }
 
-    // Auto-refresh expired OAuth tokens before connecting to HTTP servers
-    if (isHttpServer(config)) {
-      const provider = this.getOrCreateOAuthProvider(serverName);
-      if (!provider.isComplete()) {
-        throw new Error(`Not authenticated with "${serverName}". Run: mcpcli auth ${serverName}`);
+    const connectPromise = (async () => {
+      // Auto-refresh expired OAuth tokens before connecting to HTTP servers
+      if (isHttpServer(config)) {
+        const provider = this.getOrCreateOAuthProvider(serverName);
+        if (!provider.isComplete()) {
+          throw new Error(`Not authenticated with "${serverName}". Run: mcpcli auth ${serverName}`);
+        }
+        try {
+          await provider.refreshIfNeeded(config.url);
+        } catch {
+          // If refresh fails, continue — the transport will send the existing token
+        }
       }
-      try {
-        await provider.refreshIfNeeded(config.url);
-      } catch {
-        // If refresh fails, continue — the transport will send the existing token
-      }
-    }
 
-    const transport = this.createTransport(serverName, config);
-    this.transports.set(serverName, transport);
+      const transport = this.createTransport(serverName, config);
+      this.transports.set(serverName, transport);
 
-    const client = new Client({ name: "mcpcli", version: "0.1.0" });
-    await this.withTimeout(client.connect(transport), `connect(${serverName})`);
-    this.clients.set(serverName, client);
+      const client = new Client({ name: "mcpcli", version: "0.1.0" });
+      await this.withTimeout(client.connect(transport), `connect(${serverName})`);
+      this.clients.set(serverName, client);
+      this.connecting.delete(serverName);
 
-    return client;
+      return client;
+    })().catch((err) => {
+      this.connecting.delete(serverName);
+      throw err;
+    });
+
+    this.connecting.set(serverName, connectPromise);
+    return connectPromise;
   }
 
   private getOrCreateOAuthProvider(serverName: string): McpOAuthProvider {
@@ -150,6 +181,7 @@ export class ServerManager {
             // ignore close errors
           }
           this.clients.delete(serverName);
+          this.connecting.delete(serverName);
           this.transports.delete(serverName);
         }
       }
@@ -228,6 +260,128 @@ export class ServerManager {
     return tools.find((t) => t.name === toolName);
   }
 
+  /** List resources for a single server */
+  async listResources(serverName: string): Promise<Resource[]> {
+    return this.withRetry(
+      async () => {
+        const client = await this.getClient(serverName);
+        const result = await this.withTimeout(
+          client.listResources(),
+          `listResources(${serverName})`,
+        );
+        return result.resources;
+      },
+      `listResources(${serverName})`,
+      serverName,
+    );
+  }
+
+  /** List resources across all configured servers */
+  async getAllResources(): Promise<{ resources: ResourceWithServer[]; errors: ServerError[] }> {
+    const serverNames = Object.keys(this.servers.mcpServers);
+    const resources: ResourceWithServer[] = [];
+    const errors: ServerError[] = [];
+
+    for (let i = 0; i < serverNames.length; i += this.concurrency) {
+      const batch = serverNames.slice(i, i + this.concurrency);
+      const batchResults = await Promise.allSettled(
+        batch.map(async (name) => {
+          const serverResources = await this.listResources(name);
+          return serverResources.map((resource) => ({ server: name, resource }));
+        }),
+      );
+
+      for (let j = 0; j < batchResults.length; j++) {
+        const result = batchResults[j]!;
+        if (result.status === "fulfilled") {
+          resources.push(...result.value);
+        } else {
+          const name = batch[j]!;
+          const message =
+            result.reason instanceof Error ? result.reason.message : String(result.reason);
+          errors.push({ server: name, message });
+        }
+      }
+    }
+
+    return { resources, errors };
+  }
+
+  /** Read a specific resource by URI */
+  async readResource(serverName: string, uri: string): Promise<unknown> {
+    return this.withRetry(
+      async () => {
+        const client = await this.getClient(serverName);
+        return this.withTimeout(client.readResource({ uri }), `readResource(${serverName}/${uri})`);
+      },
+      `readResource(${serverName}/${uri})`,
+      serverName,
+    );
+  }
+
+  /** List prompts for a single server */
+  async listPrompts(serverName: string): Promise<Prompt[]> {
+    return this.withRetry(
+      async () => {
+        const client = await this.getClient(serverName);
+        const result = await this.withTimeout(client.listPrompts(), `listPrompts(${serverName})`);
+        return result.prompts;
+      },
+      `listPrompts(${serverName})`,
+      serverName,
+    );
+  }
+
+  /** List prompts across all configured servers */
+  async getAllPrompts(): Promise<{ prompts: PromptWithServer[]; errors: ServerError[] }> {
+    const serverNames = Object.keys(this.servers.mcpServers);
+    const prompts: PromptWithServer[] = [];
+    const errors: ServerError[] = [];
+
+    for (let i = 0; i < serverNames.length; i += this.concurrency) {
+      const batch = serverNames.slice(i, i + this.concurrency);
+      const batchResults = await Promise.allSettled(
+        batch.map(async (name) => {
+          const serverPrompts = await this.listPrompts(name);
+          return serverPrompts.map((prompt) => ({ server: name, prompt }));
+        }),
+      );
+
+      for (let j = 0; j < batchResults.length; j++) {
+        const result = batchResults[j]!;
+        if (result.status === "fulfilled") {
+          prompts.push(...result.value);
+        } else {
+          const name = batch[j]!;
+          const message =
+            result.reason instanceof Error ? result.reason.message : String(result.reason);
+          errors.push({ server: name, message });
+        }
+      }
+    }
+
+    return { prompts, errors };
+  }
+
+  /** Get a specific prompt by name, optionally with arguments */
+  async getPrompt(
+    serverName: string,
+    name: string,
+    args?: Record<string, string>,
+  ): Promise<unknown> {
+    return this.withRetry(
+      async () => {
+        const client = await this.getClient(serverName);
+        return this.withTimeout(
+          client.getPrompt({ name, arguments: args }),
+          `getPrompt(${serverName}/${name})`,
+        );
+      },
+      `getPrompt(${serverName}/${name})`,
+      serverName,
+    );
+  }
+
   /** Get all server names */
   getServerNames(): string[] {
     return Object.keys(this.servers.mcpServers);
@@ -245,6 +399,7 @@ export class ServerManager {
       this.transports.delete(name);
     });
     await Promise.allSettled(closePromises);
+    this.connecting.clear();
   }
 }
 

--- a/src/client/oauth.ts
+++ b/src/client/oauth.ts
@@ -248,6 +248,23 @@ export function startCallbackServer(): {
   return { server, authCodePromise };
 }
 
+/** Resolve the canonical resource URL for an HTTP MCP server.
+ * Some servers advertise a canonical URL in their OAuth protected resource metadata
+ * that may differ from the URL provided by the user (e.g. hf.co → huggingface.co).
+ * Returns the canonical URL if found, or the original URL otherwise. */
+export async function resolveResourceUrl(serverUrl: string): Promise<string> {
+  try {
+    const info = await discoverOAuthServerInfo(serverUrl);
+    const canonical = info.resourceMetadata?.resource;
+    if (canonical && canonical !== serverUrl) {
+      return canonical;
+    }
+  } catch {
+    // OAuth discovery not available — use original URL
+  }
+  return serverUrl;
+}
+
 /** Probe for OAuth support and run the auth flow if the server supports it.
  * Returns true if auth ran, false if server doesn't support OAuth (silent skip). */
 export async function tryOAuthIfSupported(

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import type { ServerConfig } from "../config/schemas.ts";
 import { loadRawAuth, loadRawServers, saveServers } from "../config/loader.ts";
-import { tryOAuthIfSupported } from "../client/oauth.ts";
+import { tryOAuthIfSupported, resolveResourceUrl } from "../client/oauth.ts";
 import { runIndex } from "./index.ts";
 
 export function registerAddCommand(program: Command) {
@@ -72,6 +72,20 @@ export function registerAddCommand(program: Command) {
           config.disabledTools = options.disabledTools.split(",").map((t) => t.trim());
         }
 
+        // For HTTP servers, resolve the canonical resource URL before saving.
+        // Some servers (e.g. hf.co → huggingface.co) advertise a different canonical
+        // URL in their OAuth protected resource metadata, and the SDK enforces that the
+        // stored URL matches this canonical URL during the OAuth token flow.
+        let effectiveUrl = options.url!;
+        if (hasUrl && options.auth !== false) {
+          const canonical = await resolveResourceUrl(effectiveUrl);
+          if (canonical !== effectiveUrl) {
+            (config as { url: string }).url = canonical;
+            effectiveUrl = canonical;
+            console.log(`Resolved canonical URL: ${canonical}`);
+          }
+        }
+
         servers.mcpServers[name] = config;
         await saveServers(configDir, servers);
         console.log(`Added server "${name}" to ${configDir}/servers.json`);
@@ -85,7 +99,7 @@ export function registerAddCommand(program: Command) {
             showSecrets: false,
           };
           try {
-            await tryOAuthIfSupported(name, options.url!, configDir, auth, formatOptions);
+            await tryOAuthIfSupported(name, effectiveUrl, configDir, auth, formatOptions);
           } catch {
             console.error(`Warning: OAuth authentication failed. Run: mcpcli auth ${name}`);
           }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { getContext } from "../context.ts";
-import { formatToolList, formatError } from "../output/formatter.ts";
+import { formatUnifiedList, formatError } from "../output/formatter.ts";
+import type { UnifiedItem } from "../output/formatter.ts";
 import { logger } from "../output/logger.ts";
 
 export function registerListCommand(program: Command) {
@@ -8,19 +9,52 @@ export function registerListCommand(program: Command) {
     const { manager, formatOptions } = await getContext(program);
     const spinner = logger.startSpinner("Connecting to servers...", formatOptions);
     try {
-      const { tools, errors } = await manager.getAllTools();
+      const [toolsResult, resourcesResult, promptsResult] = await Promise.all([
+        manager.getAllTools(),
+        manager.getAllResources(),
+        manager.getAllPrompts(),
+      ]);
       spinner.stop();
 
+      const items: UnifiedItem[] = [
+        ...toolsResult.tools.map((t) => ({
+          server: t.server,
+          type: "tool" as const,
+          name: t.tool.name,
+          description: t.tool.description,
+        })),
+        ...resourcesResult.resources.map((r) => ({
+          server: r.server,
+          type: "resource" as const,
+          name: r.resource.uri,
+          description: r.resource.description,
+        })),
+        ...promptsResult.prompts.map((p) => ({
+          server: p.server,
+          type: "prompt" as const,
+          name: p.prompt.name,
+          description: p.prompt.description,
+        })),
+      ];
+
+      const typeOrder = { tool: 0, resource: 1, prompt: 2 };
+      items.sort((a, b) => {
+        if (a.server !== b.server) return a.server.localeCompare(b.server);
+        if (a.type !== b.type) return typeOrder[a.type] - typeOrder[b.type];
+        return a.name.localeCompare(b.name);
+      });
+
+      const errors = [...toolsResult.errors, ...resourcesResult.errors, ...promptsResult.errors];
       if (errors.length > 0) {
         for (const err of errors) {
           console.error(`"${err.server}": ${err.message}`);
         }
-        if (tools.length > 0) console.log("");
+        if (items.length > 0) console.log("");
       }
 
-      console.log(formatToolList(tools, formatOptions));
+      console.log(formatUnifiedList(items, formatOptions));
     } catch (err) {
-      spinner.error("Failed to list tools");
+      spinner.error("Failed to list servers");
       console.error(formatError(String(err), formatOptions));
       process.exit(1);
     } finally {

--- a/src/commands/prompt.ts
+++ b/src/commands/prompt.ts
@@ -1,0 +1,85 @@
+import type { Command } from "commander";
+import { getContext } from "../context.ts";
+import {
+  formatPromptList,
+  formatServerPrompts,
+  formatPromptMessages,
+  formatError,
+} from "../output/formatter.ts";
+import { logger } from "../output/logger.ts";
+
+export function registerPromptCommand(program: Command) {
+  program
+    .command("prompt [server] [name] [args]")
+    .description("list prompts for a server, or get a specific prompt")
+    .action(
+      async (server: string | undefined, name: string | undefined, argsStr: string | undefined) => {
+        const { manager, formatOptions } = await getContext(program);
+        const spinner = logger.startSpinner(
+          server ? `Connecting to ${server}...` : "Connecting to servers...",
+          formatOptions,
+        );
+        try {
+          if (server && name) {
+            let args: Record<string, string> | undefined;
+
+            if (argsStr) {
+              args = parseJsonArgs(argsStr);
+            } else if (!process.stdin.isTTY) {
+              const stdin = await readStdin();
+              if (stdin.trim()) {
+                args = parseJsonArgs(stdin);
+              }
+            }
+
+            const result = await manager.getPrompt(server, name, args);
+            spinner.stop();
+            console.log(formatPromptMessages(server, name, result, formatOptions));
+          } else if (server) {
+            const prompts = await manager.listPrompts(server);
+            spinner.stop();
+            console.log(formatServerPrompts(server, prompts, formatOptions));
+          } else {
+            const { prompts, errors } = await manager.getAllPrompts();
+            spinner.stop();
+            console.log(formatPromptList(prompts, formatOptions));
+            for (const err of errors) {
+              console.error(formatError(`${err.server}: ${err.message}`, formatOptions));
+            }
+          }
+        } catch (err) {
+          spinner.error("Failed");
+          console.error(formatError(String(err), formatOptions));
+          process.exit(1);
+        } finally {
+          await manager.close();
+        }
+      },
+    );
+}
+
+function parseJsonArgs(str: string): Record<string, string> {
+  try {
+    const parsed = JSON.parse(str);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("Prompt arguments must be a JSON object");
+    }
+    // Coerce all values to strings (MCP prompt args are Record<string, string>)
+    return Object.fromEntries(Object.entries(parsed).map(([k, v]) => [k, String(v)]));
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new Error(`Invalid JSON: ${err.message}`);
+    }
+    throw err;
+  }
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: string[] = [];
+  const reader = process.stdin;
+  reader.setEncoding("utf-8");
+  for await (const chunk of reader) {
+    chunks.push(chunk as string);
+  }
+  return chunks.join("");
+}

--- a/src/commands/resource.ts
+++ b/src/commands/resource.ts
@@ -1,0 +1,46 @@
+import type { Command } from "commander";
+import { getContext } from "../context.ts";
+import {
+  formatResourceList,
+  formatServerResources,
+  formatResourceContents,
+  formatError,
+} from "../output/formatter.ts";
+import { logger } from "../output/logger.ts";
+
+export function registerResourceCommand(program: Command) {
+  program
+    .command("resource [server] [uri]")
+    .description("list resources for a server, or read a specific resource")
+    .action(async (server: string | undefined, uri: string | undefined) => {
+      const { manager, formatOptions } = await getContext(program);
+      const spinner = logger.startSpinner(
+        server ? `Connecting to ${server}...` : "Connecting to servers...",
+        formatOptions,
+      );
+      try {
+        if (server && uri) {
+          const result = await manager.readResource(server, uri);
+          spinner.stop();
+          console.log(formatResourceContents(server, uri, result, formatOptions));
+        } else if (server) {
+          const resources = await manager.listResources(server);
+          spinner.stop();
+          console.log(formatServerResources(server, resources, formatOptions));
+        } else {
+          const { resources, errors } = await manager.getAllResources();
+          spinner.stop();
+          console.log(formatResourceList(resources, formatOptions));
+          for (const err of errors) {
+            console.error(formatError(`${err.server}: ${err.message}`, formatOptions));
+          }
+        }
+      } catch (err) {
+        spinner.error("Failed");
+        console.error(formatError(String(err), formatOptions));
+        process.exit(1);
+      } finally {
+        await manager.close();
+      }
+    });
+}

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -1,4 +1,4 @@
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool, Resource, Prompt } from "@modelcontextprotocol/sdk/types.js";
 import type {
   OAuthTokens,
   OAuthClientInformation,
@@ -6,7 +6,14 @@ import type {
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 
 // Re-export SDK types we use throughout the codebase
-export type { Tool, OAuthTokens, OAuthClientInformation, OAuthClientInformationMixed };
+export type {
+  Tool,
+  Resource,
+  Prompt,
+  OAuthTokens,
+  OAuthClientInformation,
+  OAuthClientInformationMixed,
+};
 
 // --- Server config (our format, not MCP spec) ---
 

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -1,6 +1,6 @@
 import { bold, cyan, dim, green, red, yellow } from "ansis";
-import type { Tool } from "../config/schemas.ts";
-import type { ToolWithServer } from "../client/manager.ts";
+import type { Tool, Resource, Prompt } from "../config/schemas.ts";
+import type { ToolWithServer, ResourceWithServer, PromptWithServer } from "../client/manager.ts";
 import type { ValidationError } from "../validation/schema.ts";
 import type { SearchResult } from "../search/index.ts";
 
@@ -9,6 +9,13 @@ export interface FormatOptions {
   withDescriptions?: boolean;
   verbose?: boolean;
   showSecrets?: boolean;
+}
+
+export interface UnifiedItem {
+  server: string;
+  type: "tool" | "resource" | "prompt";
+  name: string;
+  description?: string;
 }
 
 /** Check if stdout is a TTY (interactive terminal) */
@@ -303,6 +310,273 @@ export function formatSearchResults(results: SearchResult[], options: FormatOpti
         .map((l) => `${indent}${dim(l.trim())}`)
         .join("\n");
       return `${line}\n${rest}`;
+    })
+    .join("\n");
+}
+
+/** Format a list of resources with server names */
+export function formatResourceList(
+  resources: ResourceWithServer[],
+  options: FormatOptions,
+): string {
+  if (!isInteractive(options)) {
+    return JSON.stringify(
+      resources.map((r) => ({
+        server: r.server,
+        uri: r.resource.uri,
+        name: r.resource.name,
+        ...(options.withDescriptions ? { description: r.resource.description ?? "" } : {}),
+      })),
+      null,
+      2,
+    );
+  }
+
+  if (resources.length === 0) {
+    return dim("No resources found");
+  }
+
+  const maxServer = Math.max(...resources.map((r) => r.server.length));
+  const maxUri = Math.max(...resources.map((r) => r.resource.uri.length));
+
+  return resources
+    .map((r) => {
+      const server = cyan(r.server.padEnd(maxServer));
+      const uri = bold(r.resource.uri.padEnd(maxUri));
+      if (options.withDescriptions && r.resource.description) {
+        return `${server}  ${uri}  ${dim(r.resource.description)}`;
+      }
+      return `${server}  ${uri}`;
+    })
+    .join("\n");
+}
+
+/** Format resources for a single server */
+export function formatServerResources(
+  serverName: string,
+  resources: Resource[],
+  options: FormatOptions,
+): string {
+  if (!isInteractive(options)) {
+    return JSON.stringify(
+      {
+        server: serverName,
+        resources: resources.map((r) => ({
+          uri: r.uri,
+          name: r.name,
+          description: r.description ?? "",
+          mimeType: r.mimeType ?? "",
+        })),
+      },
+      null,
+      2,
+    );
+  }
+
+  if (resources.length === 0) {
+    return dim(`No resources found for ${serverName}`);
+  }
+
+  const header = cyan.bold(serverName);
+  const maxUri = Math.max(...resources.map((r) => r.uri.length));
+
+  const lines = resources.map((r) => {
+    const uri = `  ${bold(r.uri.padEnd(maxUri))}`;
+    if (r.description) {
+      return `${uri}  ${dim(r.description)}`;
+    }
+    return uri;
+  });
+
+  return [header, ...lines].join("\n");
+}
+
+/** Format resource contents */
+export function formatResourceContents(
+  serverName: string,
+  uri: string,
+  result: unknown,
+  options: FormatOptions,
+): string {
+  if (!isInteractive(options)) {
+    return JSON.stringify(
+      { server: serverName, uri, contents: (result as { contents: unknown })?.contents ?? result },
+      null,
+      2,
+    );
+  }
+
+  const contents =
+    (result as { contents?: Array<{ text?: string; blob?: string; mimeType?: string }> })
+      ?.contents ?? [];
+  const lines: string[] = [];
+  lines.push(`${cyan(serverName)}/${bold(uri)}`);
+  lines.push("");
+
+  if (contents.length === 0) {
+    lines.push(dim("(empty)"));
+  } else {
+    for (const item of contents) {
+      if (item.text !== undefined) {
+        lines.push(item.text);
+      } else if (item.blob !== undefined) {
+        lines.push(dim(`<binary blob, ${item.blob.length} bytes base64>`));
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Format a list of prompts with server names */
+export function formatPromptList(prompts: PromptWithServer[], options: FormatOptions): string {
+  if (!isInteractive(options)) {
+    return JSON.stringify(
+      prompts.map((p) => ({
+        server: p.server,
+        name: p.prompt.name,
+        ...(options.withDescriptions ? { description: p.prompt.description ?? "" } : {}),
+      })),
+      null,
+      2,
+    );
+  }
+
+  if (prompts.length === 0) {
+    return dim("No prompts found");
+  }
+
+  const maxServer = Math.max(...prompts.map((p) => p.server.length));
+  const maxName = Math.max(...prompts.map((p) => p.prompt.name.length));
+
+  return prompts
+    .map((p) => {
+      const server = cyan(p.server.padEnd(maxServer));
+      const name = bold(p.prompt.name.padEnd(maxName));
+      if (options.withDescriptions && p.prompt.description) {
+        return `${server}  ${name}  ${dim(p.prompt.description)}`;
+      }
+      return `${server}  ${name}`;
+    })
+    .join("\n");
+}
+
+/** Format prompts for a single server */
+export function formatServerPrompts(
+  serverName: string,
+  prompts: Prompt[],
+  options: FormatOptions,
+): string {
+  if (!isInteractive(options)) {
+    return JSON.stringify(
+      {
+        server: serverName,
+        prompts: prompts.map((p) => ({
+          name: p.name,
+          description: p.description ?? "",
+          arguments: p.arguments ?? [],
+        })),
+      },
+      null,
+      2,
+    );
+  }
+
+  if (prompts.length === 0) {
+    return dim(`No prompts found for ${serverName}`);
+  }
+
+  const header = cyan.bold(serverName);
+  const maxName = Math.max(...prompts.map((p) => p.name.length));
+
+  const lines = prompts.map((p) => {
+    const name = `  ${bold(p.name.padEnd(maxName))}`;
+    const args =
+      p.arguments && p.arguments.length > 0
+        ? `  ${dim(`(${p.arguments.map((a) => (a.required ? a.name : `[${a.name}]`)).join(", ")})`)}`
+        : "";
+    if (p.description) {
+      return `${name}${args}  ${dim(p.description)}`;
+    }
+    return `${name}${args}`;
+  });
+
+  return [header, ...lines].join("\n");
+}
+
+/** Format prompt messages */
+export function formatPromptMessages(
+  serverName: string,
+  name: string,
+  result: unknown,
+  options: FormatOptions,
+): string {
+  if (!isInteractive(options)) {
+    return JSON.stringify({ server: serverName, prompt: name, ...(result as object) }, null, 2);
+  }
+
+  const r = result as {
+    description?: string;
+    messages?: Array<{ role: string; content: { type: string; text?: string } }>;
+  };
+  const lines: string[] = [];
+  lines.push(`${cyan(serverName)}/${bold(name)}`);
+
+  if (r.description) {
+    lines.push(dim(r.description));
+  }
+
+  lines.push("");
+
+  for (const msg of r.messages ?? []) {
+    lines.push(`${bold(msg.role)}:`);
+    if (msg.content.text !== undefined) {
+      lines.push(`  ${msg.content.text}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Format a unified list of tools, resources, and prompts across servers */
+export function formatUnifiedList(items: UnifiedItem[], options: FormatOptions): string {
+  if (!isInteractive(options)) {
+    return JSON.stringify(
+      items.map((i) => ({
+        server: i.server,
+        type: i.type,
+        name: i.name,
+        ...(options.withDescriptions ? { description: i.description ?? "" } : {}),
+      })),
+      null,
+      2,
+    );
+  }
+
+  if (items.length === 0) {
+    return dim("No tools, resources, or prompts found");
+  }
+
+  const maxServer = Math.max(...items.map((i) => i.server.length));
+  const maxType = 8; // "resource" is the longest at 8 chars
+  const maxName = Math.max(...items.map((i) => i.name.length));
+
+  const typeLabel = (t: UnifiedItem["type"]) => {
+    const padded = t.padEnd(maxType);
+    if (t === "tool") return green(padded);
+    if (t === "resource") return cyan(padded);
+    return yellow(padded);
+  };
+
+  return items
+    .map((i) => {
+      const server = cyan(i.server.padEnd(maxServer));
+      const type = typeLabel(i.type);
+      const name = bold(i.name.padEnd(maxName));
+      if (options.withDescriptions && i.description) {
+        return `${server}  ${type}  ${name}  ${dim(i.description)}`;
+      }
+      return `${server}  ${type}  ${name}`;
     })
     .join("\n");
 }

--- a/test/commands/list.test.ts
+++ b/test/commands/list.test.ts
@@ -13,27 +13,67 @@ function run(...args: string[]) {
 }
 
 describe("mcpcli (list)", () => {
-  test("lists tools from mock server as JSON when piped", async () => {
+  test("lists tools, resources, and prompts from mock server as JSON when piped", async () => {
     const proc = run("--json");
     const exitCode = await proc.exited;
     const stdout = await new Response(proc.stdout).text();
     expect(exitCode).toBe(0);
 
-    const tools = JSON.parse(stdout);
-    expect(Array.isArray(tools)).toBe(true);
-    const names = tools.map((t: { tool: string }) => t.tool);
+    const items = JSON.parse(stdout);
+    expect(Array.isArray(items)).toBe(true);
+
+    const types = items.map((i: { type: string }) => i.type);
+    expect(types).toContain("tool");
+    expect(types).toContain("resource");
+    expect(types).toContain("prompt");
+
+    const names = items.map((i: { name: string }) => i.name);
     expect(names).toContain("echo");
-    expect(names).toContain("add");
+    expect(names).toContain("file:///hello.txt");
+    expect(names).toContain("greet");
   });
 
-  test("lists tools with descriptions", async () => {
+  test("items include server and name fields", async () => {
+    const proc = run("--json");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const items = JSON.parse(stdout);
+    const echo = items.find((i: { name: string }) => i.name === "echo");
+    expect(echo.server).toBe("mock");
+    expect(echo.type).toBe("tool");
+  });
+
+  test("lists items with descriptions when -d flag is set", async () => {
     const proc = run("--json", "-d");
     const exitCode = await proc.exited;
     const stdout = await new Response(proc.stdout).text();
     expect(exitCode).toBe(0);
 
-    const tools = JSON.parse(stdout);
-    const echo = tools.find((t: { tool: string }) => t.tool === "echo");
+    const items = JSON.parse(stdout);
+    const echo = items.find((i: { name: string }) => i.name === "echo");
     expect(echo.description).toContain("Echoes");
+  });
+
+  test("items are sorted by server, then type (tool < resource < prompt), then name", async () => {
+    const proc = run("--json");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const items: { server: string; type: string; name: string }[] = JSON.parse(stdout);
+    const typeOrder: Record<string, number> = { tool: 0, resource: 1, prompt: 2 };
+
+    for (let i = 1; i < items.length; i++) {
+      const a = items[i - 1]!;
+      const b = items[i]!;
+      if (a.server === b.server && a.type === b.type) {
+        expect(a.name.localeCompare(b.name)).toBeLessThanOrEqual(0);
+      }
+      if (a.server === b.server) {
+        expect(typeOrder[a.type]!).toBeLessThanOrEqual(typeOrder[b.type]!);
+      }
+    }
   });
 });

--- a/test/commands/prompt.test.ts
+++ b/test/commands/prompt.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "bun:test";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "../../src/cli.ts");
+const CONFIG = join(import.meta.dir, "../fixtures/mock-config");
+
+function run(...args: string[]) {
+  return Bun.spawn(["bun", "run", CLI, "-c", CONFIG, "--json", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: join(import.meta.dir, "../.."),
+  });
+}
+
+describe("mcpcli prompts", () => {
+  test("prompts <server> lists prompts for that server", async () => {
+    const proc = run("prompt", "mock");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.server).toBe("mock");
+    expect(Array.isArray(result.prompts)).toBe(true);
+    expect(result.prompts.length).toBeGreaterThan(0);
+    expect(result.prompts.map((p: { name: string }) => p.name)).toContain("greet");
+  });
+
+  test("prompts <server> <name> gets a specific prompt", async () => {
+    const proc = run("prompt", "mock", "greet", '{"name":"World"}');
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.server).toBe("mock");
+    expect(result.prompt).toBe("greet");
+    expect(Array.isArray(result.messages)).toBe(true);
+    expect(result.messages.length).toBeGreaterThan(0);
+  });
+
+  test("prompts <server> <name> works without arguments", async () => {
+    const proc = run("prompt", "mock", "summarize");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.server).toBe("mock");
+    expect(result.prompt).toBe("summarize");
+    expect(Array.isArray(result.messages)).toBe(true);
+  });
+
+  test("prompts lists all prompts across servers", async () => {
+    const proc = run("prompt");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toHaveProperty("server");
+    expect(result[0]).toHaveProperty("name");
+  });
+
+  test("prompts <server> <name> errors on unknown prompt", async () => {
+    const proc = run("prompt", "mock", "nonexistent");
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/commands/resource.test.ts
+++ b/test/commands/resource.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "bun:test";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "../../src/cli.ts");
+const CONFIG = join(import.meta.dir, "../fixtures/mock-config");
+
+function run(...args: string[]) {
+  return Bun.spawn(["bun", "run", CLI, "-c", CONFIG, "--json", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: join(import.meta.dir, "../.."),
+  });
+}
+
+describe("mcpcli resources", () => {
+  test("resources <server> lists resources for that server", async () => {
+    const proc = run("resource", "mock");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.server).toBe("mock");
+    expect(Array.isArray(result.resources)).toBe(true);
+    expect(result.resources.length).toBeGreaterThan(0);
+    expect(result.resources.map((r: { uri: string }) => r.uri)).toContain("file:///hello.txt");
+  });
+
+  test("resources <server> <uri> reads a specific resource", async () => {
+    const proc = run("resource", "mock", "file:///hello.txt");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.server).toBe("mock");
+    expect(result.uri).toBe("file:///hello.txt");
+    expect(result.contents).toBeDefined();
+  });
+
+  test("resources lists all resources across servers", async () => {
+    const proc = run("resource");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toHaveProperty("server");
+    expect(result[0]).toHaveProperty("uri");
+  });
+
+  test("resources <server> <uri> errors on unknown URI", async () => {
+    const proc = run("resource", "mock", "file:///nonexistent.txt");
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/fixtures/mock-server.ts
+++ b/test/fixtures/mock-server.ts
@@ -36,11 +36,75 @@ function handleMessage(line: string) {
   if (msg.method === "initialize") {
     respond(msg.id, {
       protocolVersion: "2025-03-26",
-      capabilities: { tools: {} },
+      capabilities: { tools: {}, resources: {}, prompts: {} },
       serverInfo: { name: "mock-server", version: "1.0.0" },
     });
   } else if (msg.method === "notifications/initialized") {
     // No response needed for notifications
+  } else if (msg.method === "resources/list") {
+    respond(msg.id, {
+      resources: [
+        {
+          uri: "file:///hello.txt",
+          name: "Hello File",
+          description: "A simple greeting file",
+          mimeType: "text/plain",
+        },
+        {
+          uri: "file:///data.json",
+          name: "Data File",
+          description: "Some JSON data",
+          mimeType: "application/json",
+        },
+      ],
+    });
+  } else if (msg.method === "resources/read") {
+    const params = msg.params as { uri: string };
+    if (params.uri === "file:///hello.txt") {
+      respond(msg.id, {
+        contents: [{ uri: params.uri, mimeType: "text/plain", text: "Hello, World!" }],
+      });
+    } else if (params.uri === "file:///data.json") {
+      respond(msg.id, {
+        contents: [
+          { uri: params.uri, mimeType: "application/json", text: '{"key":"value","count":42}' },
+        ],
+      });
+    } else {
+      respond(msg.id, { error: { code: -32602, message: `Resource not found: ${params.uri}` } });
+    }
+  } else if (msg.method === "prompts/list") {
+    respond(msg.id, {
+      prompts: [
+        {
+          name: "greet",
+          description: "Generate a greeting message",
+          arguments: [{ name: "name", description: "Name to greet", required: true }],
+        },
+        {
+          name: "summarize",
+          description: "Summarize some text",
+          arguments: [{ name: "text", description: "Text to summarize", required: false }],
+        },
+      ],
+    });
+  } else if (msg.method === "prompts/get") {
+    const params = msg.params as { name: string; arguments?: Record<string, string> };
+    if (params.name === "greet") {
+      const name = params.arguments?.name ?? "World";
+      respond(msg.id, {
+        description: "A greeting prompt",
+        messages: [{ role: "user", content: { type: "text", text: `Hello, ${name}!` } }],
+      });
+    } else if (params.name === "summarize") {
+      const text = params.arguments?.text ?? "(no text provided)";
+      respond(msg.id, {
+        description: "A summarize prompt",
+        messages: [{ role: "user", content: { type: "text", text: `Please summarize: ${text}` } }],
+      });
+    } else {
+      respond(msg.id, { error: { code: -32602, message: `Prompt not found: ${params.name}` } });
+    }
   } else if (msg.method === "tools/list") {
     respond(msg.id, {
       tools: [

--- a/test/integration/stdio-server.test.ts
+++ b/test/integration/stdio-server.test.ts
@@ -29,26 +29,36 @@ async function runAndParse<T = unknown>(...args: string[]): Promise<T> {
 }
 
 describe("stdio MCP server integration", () => {
-  test("lists all tools from the mock stdio server", async () => {
-    const tools = await runAndParse<{ server: string; tool: string }[]>();
-    expect(tools).toBeInstanceOf(Array);
+  test("lists all tools, resources, and prompts from the mock stdio server", async () => {
+    const items = await runAndParse<{ server: string; type: string; name: string }[]>();
+    expect(items).toBeInstanceOf(Array);
+
+    const tools = items.filter((i) => i.type === "tool");
+    const resources = items.filter((i) => i.type === "resource");
+    const prompts = items.filter((i) => i.type === "prompt");
+
     expect(tools.length).toBe(4);
+    expect(resources.length).toBeGreaterThan(0);
+    expect(prompts.length).toBeGreaterThan(0);
 
-    const names = tools.map((t) => t.tool);
-    expect(names).toContain("echo");
-    expect(names).toContain("add");
-    expect(names).toContain("secret");
-    expect(names).toContain("noop");
+    const toolNames = tools.map((t) => t.name);
+    expect(toolNames).toContain("echo");
+    expect(toolNames).toContain("add");
+    expect(toolNames).toContain("secret");
+    expect(toolNames).toContain("noop");
 
-    // Every tool should be from the "mock" server
-    for (const t of tools) {
-      expect(t.server).toBe("mock");
+    // Every item should be from the "mock" server
+    for (const item of items) {
+      expect(item.server).toBe("mock");
     }
   });
 
-  test("lists tools with descriptions", async () => {
-    const tools = await runAndParse<{ server: string; tool: string; description: string }[]>("-d");
-    const echo = tools.find((t) => t.tool === "echo");
+  test("lists items with descriptions", async () => {
+    const items =
+      await runAndParse<{ server: string; type: string; name: string; description: string }[]>(
+        "-d",
+      );
+    const echo = items.find((i) => i.type === "tool" && i.name === "echo");
     expect(echo).toBeDefined();
     expect(echo!.description).toContain("Echoes");
   });


### PR DESCRIPTION
## Summary

Adds `mcpcli resources` and `mcpcli prompts` commands to expose MCP's three core primitives (tools, resources, and prompts) via the CLI.

- New commands: `mcpcli resources [server] [uri]` and `mcpcli prompts [server] [name]`
- Extended ServerManager with resource/prompt listing and reading methods
- Added dual-mode formatters (interactive terminal and JSON output)
- 9 new integration tests, all passing
- Mock server updated to support resources and prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)