### PR TITLE
Add mcpcli servers command and fix unknown command error

### DIFF
--- a/.claude/skills/mcpcli.md
+++ b/.claude/skills/mcpcli.md
@@ -73,6 +73,7 @@ mcpcli deauth <server>      # remove stored auth
 | Command                                | Purpose                           |
 | -------------------------------------- | --------------------------------- |
 | `mcpcli`                               | List all servers and tools        |
+| `mcpcli servers`                       | List servers (name, type, detail) |
 | `mcpcli -d`                            | List with descriptions            |
 | `mcpcli info <server>`                 | Show tools for a server           |
 | `mcpcli info <server> <tool>`          | Show tool schema                  |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ mcpcli search -q "manage pull requests"
 | Command                                | Description                                  |
 | -------------------------------------- | -------------------------------------------- |
 | `mcpcli`                               | List all configured servers and tools        |
+| `mcpcli servers`                       | List configured servers (name, type, detail) |
 | `mcpcli info <server>`                 | Show tools for a server                      |
 | `mcpcli info <server> <tool>`          | Show tool schema                             |
 | `mcpcli search <query>`                | Search tools (keyword + semantic)            |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { registerSkillCommand } from "./commands/skill.ts";
 import { registerPingCommand } from "./commands/ping.ts";
 import { registerResourceCommand } from "./commands/resource.ts";
 import { registerPromptCommand } from "./commands/prompt.ts";
+import { registerServersCommand } from "./commands/servers.ts";
 
 declare const BUILD_VERSION: string | undefined;
 
@@ -41,5 +42,25 @@ registerSkillCommand(program);
 registerPingCommand(program);
 registerResourceCommand(program);
 registerPromptCommand(program);
+registerServersCommand(program);
+
+// Detect unknown subcommands before commander misreports them as "too many arguments"
+const knownCommands = new Set(program.commands.map((c) => c.name()));
+const cliArgs = process.argv.slice(2);
+let firstCommand: string | undefined;
+for (let i = 0; i < cliArgs.length; i++) {
+  const a = cliArgs[i];
+  if (a === "-c" || a === "--config") {
+    i++; // skip the config path value
+    continue;
+  }
+  if (a.startsWith("-")) continue;
+  firstCommand = a;
+  break;
+}
+if (firstCommand && !knownCommands.has(firstCommand)) {
+  console.error(`error: unknown command '${firstCommand}'. See 'mcpcli --help'.`);
+  process.exit(1);
+}
 
 program.parse();

--- a/src/commands/servers.ts
+++ b/src/commands/servers.ts
@@ -1,0 +1,58 @@
+import { cyan, dim, green, yellow } from "ansis";
+import type { Command } from "commander";
+import { getContext } from "../context.ts";
+import { isStdioServer } from "../config/schemas.ts";
+import { formatError, isInteractive } from "../output/formatter.ts";
+
+export function registerServersCommand(program: Command) {
+  program
+    .command("servers")
+    .description("List configured MCP servers")
+    .action(async () => {
+      const { manager, config, formatOptions } = await getContext(program);
+      try {
+        const servers = Object.entries(config.servers.mcpServers);
+
+        if (!isInteractive(formatOptions)) {
+          console.log(
+            JSON.stringify(
+              servers.map(([name, cfg]) => ({
+                name,
+                type: isStdioServer(cfg) ? "stdio" : "http",
+                ...(isStdioServer(cfg)
+                  ? { command: cfg.command, args: cfg.args ?? [] }
+                  : { url: cfg.url }),
+              })),
+              null,
+              2,
+            ),
+          );
+          return;
+        }
+
+        if (servers.length === 0) {
+          console.log(dim("No servers configured"));
+          return;
+        }
+
+        const maxName = Math.max(...servers.map(([n]) => n.length));
+        const maxType = 5; // "stdio" / "http "
+
+        for (const [name, cfg] of servers) {
+          const n = cyan(name.padEnd(maxName));
+          const type = isStdioServer(cfg)
+            ? green("stdio".padEnd(maxType))
+            : yellow("http ".padEnd(maxType));
+          const detail = isStdioServer(cfg)
+            ? dim([cfg.command, ...(cfg.args ?? [])].join(" "))
+            : dim(cfg.url);
+          console.log(`${n}  ${type}  ${detail}`);
+        }
+      } catch (err) {
+        console.error(formatError(String(err), formatOptions));
+        process.exit(1);
+      } finally {
+        await manager.close();
+      }
+    });
+}


### PR DESCRIPTION
## Summary

- Implement new `mcpcli servers` subcommand to list configured MCP servers with their type (stdio/http) and connection details (command+args or URL)
- Fix misleading error message when typing unknown subcommands — now shows `error: unknown command 'foo'` instead of `error: too many arguments`
- Bump version to 0.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)