### PR TITLE
Fix --version to read from package.json instead of hardcoded fallback

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -109,7 +109,6 @@ jobs:
         run: |
           bun build --compile --minify --sourcemap \
             --target=${{ matrix.target }} \
-            --define BUILD_VERSION="'\"${{ needs.check-version.outputs.version }}\"'" \
             ./src/cli.ts --outfile dist/${{ matrix.artifact }}
       - name: Upload to release
         run: gh release upload "${{ needs.check-version.outputs.tag }}" dist/${{ matrix.artifact }} --clobber

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,14 +15,12 @@ import { registerResourceCommand } from "./commands/resource.ts";
 import { registerPromptCommand } from "./commands/prompt.ts";
 import { registerServersCommand } from "./commands/servers.ts";
 
-declare const BUILD_VERSION: string | undefined;
-
-const version = typeof BUILD_VERSION !== "undefined" ? BUILD_VERSION : "0.1.0-dev";
+import pkg from "../package.json";
 
 program
   .name("mcpcli")
   .description("A command-line interface for MCP servers. curl for MCP.")
-  .version(version)
+  .version(pkg.version)
   .option("-c, --config <path>", "config directory path")
   .option("-d, --with-descriptions", "include tool descriptions in output")
   .option("-j, --json", "force JSON output")

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { join } from "path";
+import pkg from "../package.json";
 
 const CONFIG = join(import.meta.dir, "fixtures/mock-config");
 
@@ -24,7 +25,7 @@ describe("mcpcli", () => {
     const exitCode = await proc.exited;
     const stdout = await new Response(proc.stdout).text();
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    expect(stdout.trim()).toBe(pkg.version);
   });
 
   test("default command runs without error", async () => {


### PR DESCRIPTION
## Summary
- Replace the `BUILD_VERSION` compile-time constant with a direct `import pkg from "../package.json"` — version is now always read from `package.json` in both dev and compiled binaries
- Remove the `--define BUILD_VERSION=...` flag from the CI build step since it's no longer needed
- Tighten the `--version` test to assert an exact match against `package.json`
- Bump version to 0.7.2

Previously, `mcpcli --version` showed `0.1.0-dev` in development because `BUILD_VERSION` was only injected at compile time in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)