### PR TITLE
Add mcpcli identification headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -3,6 +3,7 @@ import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.
 import { dim } from "ansis";
 import type { HttpServerConfig } from "../config/schemas.ts";
 import { logger } from "../output/logger.ts";
+import pkg from "../../package.json";
 
 type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
 
@@ -13,13 +14,15 @@ export function createHttpTransport(
   showSecrets = false,
 ): StreamableHTTPClientTransport {
   const requestInit: RequestInit = {};
-  if (config.headers) {
-    requestInit.headers = config.headers;
-  }
+  const userAgent = `${pkg.name}/${pkg.version}`;
+  requestInit.headers = {
+    "User-Agent": userAgent,
+    ...config.headers,
+  };
 
   return new StreamableHTTPClientTransport(new URL(config.url), {
     authProvider,
-    requestInit: Object.keys(requestInit).length > 0 ? requestInit : undefined,
+    requestInit,
     fetch: verbose ? createDebugFetch(showSecrets) : undefined,
   });
 }

--- a/src/client/manager.ts
+++ b/src/client/manager.ts
@@ -1,6 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import picomatch from "picomatch";
+import pkg from "../../package.json";
 import type {
   Tool,
   Resource,
@@ -101,7 +102,7 @@ export class ServerManager {
       const transport = this.createTransport(serverName, config);
       this.transports.set(serverName, transport);
 
-      const client = new Client({ name: "mcpcli", version: "0.1.0" });
+      const client = new Client({ name: pkg.name, version: pkg.version });
       await this.withTimeout(client.connect(transport), `connect(${serverName})`);
       this.clients.set(serverName, client);
       this.connecting.delete(serverName);


### PR DESCRIPTION
Identify mcpcli client to MCP servers via standard channels:

- **MCP protocol**: Use actual package name/version in Client initialize handshake (was hardcoded to v0.1.0)
- **HTTP transport**: Add User-Agent header to all requests (mcpcli/0.7.3)

This enables MCP servers to identify the client making requests and its version, improving observability and debugging.