### PR TITLE
Add SSE transport support with auto-fallback and explicit override

### DIFF
--- a/.claude/skills/mcpcli.md
+++ b/.claude/skills/mcpcli.md
@@ -92,6 +92,7 @@ mcpcli deauth <server>      # remove stored auth
 | `mcpcli ping <server> [server2...]`    | Check specific server(s)          |
 | `mcpcli add <name> --command <cmd>`    | Add a stdio MCP server            |
 | `mcpcli add <name> --url <url>`        | Add an HTTP MCP server            |
+| `mcpcli add <name> --url <url> --transport sse` | Add a legacy SSE server  |
 | `mcpcli remove <name>`                 | Remove an MCP server              |
 | `mcpcli skill install --claude`        | Install mcpcli skill for Claude   |
 | `mcpcli resource`                     | List all resources across servers |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ mcpcli add my-api --url https://api.example.com/mcp --header "Authorization:Bear
 # Add with tool filtering
 mcpcli add github --url https://mcp.github.com --allowed-tools "search_*,get_*"
 
+# Add a legacy SSE server (explicit transport)
+mcpcli add legacy-api --url https://api.example.com/sse --transport sse
+
 # Add with environment variables
 mcpcli add my-server --command node --args "server.js" --env "API_KEY=sk-123,DEBUG=true"
 
@@ -131,6 +134,7 @@ mcpcli remove my-api --dry-run
 | `--cwd <dir>`              | Working directory for the command      |
 | `--url <url>`              | Server URL (HTTP server)               |
 | `--header <Key:Value>`     | HTTP header (repeatable)               |
+| `--transport <type>`       | Transport: `sse` or `streamable-http`  |
 | `--allowed-tools <t1,t2>`  | Comma-separated allowed tool patterns  |
 | `--disabled-tools <t1,t2>` | Comma-separated disabled tool patterns |
 | `-f, --force`              | Overwrite if server already exists     |
@@ -166,13 +170,17 @@ Standard MCP server config format. Supports both stdio and HTTP servers.
     "internal-api": {
       "url": "https://mcp.internal.example.com",
       "headers": { "Authorization": "Bearer ${TOKEN}" }
+    },
+    "legacy-sse": {
+      "url": "https://legacy.example.com/sse",
+      "transport": "sse"
     }
   }
 }
 ```
 
 **Stdio servers** — `command` + `args`, spawned as child processes
-**HTTP servers** — `url`, with optional static `headers` for pre-shared tokens. OAuth is auto-discovered at connection time via `.well-known/oauth-authorization-server` — no config needed.
+**HTTP servers** — `url`, with optional static `headers` for pre-shared tokens. OAuth is auto-discovered at connection time via `.well-known/oauth-authorization-server` — no config needed. By default, mcpcli tries Streamable HTTP first and automatically falls back to legacy SSE if the server doesn't support it. Set `"transport": "sse"` or `"transport": "streamable-http"` to skip auto-detection.
 
 Environment variables are interpolated via `${VAR_NAME}` syntax. Set `MCP_STRICT_ENV=false` to warn instead of error on missing variables.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.7.3",
+<<<<<<< HEAD
+  "version": "0.8.0",
+=======
+  "version": "0.8.0",
+>>>>>>> b65d5f1 (Add SSE transport support with auto-fallback and explicit override)
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/client/debug-fetch.ts
+++ b/src/client/debug-fetch.ts
@@ -1,0 +1,79 @@
+import { dim } from "ansis";
+import { logger } from "../output/logger.ts";
+
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+
+export function createDebugFetch(showSecrets: boolean): FetchLike {
+  const isTTY = process.stderr.isTTY ?? false;
+  const fmt = (s: string) => (isTTY ? dim(s) : s);
+
+  return async (url, init) => {
+    const start = performance.now();
+
+    // Request
+    log(fmt(`> ${init?.method ?? "GET"} ${url}`));
+    logHeaders(">", init?.headers, fmt, showSecrets);
+    log(fmt(">"));
+    if (init?.body) {
+      logBody(String(init.body), fmt);
+    }
+
+    const response = await fetch(url, init);
+    const elapsed = Math.round(performance.now() - start);
+
+    // Response
+    log(fmt(`< ${response.status} ${response.statusText} (${elapsed}ms)`));
+    logHeaders("<", response.headers, fmt, showSecrets);
+    log(fmt("<"));
+
+    return response;
+  };
+}
+
+function log(line: string) {
+  logger.writeRaw(line + "\n");
+}
+
+function logHeaders(
+  prefix: string,
+  headers: HeadersInit | Headers | undefined,
+  fmt: (s: string) => string,
+  showSecrets: boolean,
+) {
+  if (!headers) return;
+
+  const format = (key: string, value: string) =>
+    fmt(`${prefix} ${key}: ${showSecrets ? value : maskSensitive(key, value)}`);
+
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => log(format(key, value)));
+  } else if (Array.isArray(headers)) {
+    for (const [key, value] of headers) {
+      log(format(key, value));
+    }
+  } else {
+    for (const [key, value] of Object.entries(headers)) {
+      log(format(key, value));
+    }
+  }
+}
+
+function logBody(body: string, fmt: (s: string) => string) {
+  try {
+    const formatted = JSON.stringify(JSON.parse(body), null, 2);
+    for (const line of formatted.split("\n")) {
+      log(fmt(line));
+    }
+  } catch {
+    log(fmt(body));
+  }
+}
+
+export function maskSensitive(key: string, value: string): string {
+  const lower = key.toLowerCase();
+  if (lower === "authorization" || lower === "cookie" || lower === "set-cookie") {
+    if (value.length <= 12) return value;
+    return value.slice(0, 12) + "...";
+  }
+  return value;
+}

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -1,11 +1,8 @@
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import { dim } from "ansis";
 import type { HttpServerConfig } from "../config/schemas.ts";
-import { logger } from "../output/logger.ts";
 import pkg from "../../package.json";
-
-type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+import { createDebugFetch } from "./debug-fetch.ts";
 
 export function createHttpTransport(
   config: HttpServerConfig,
@@ -25,79 +22,4 @@ export function createHttpTransport(
     requestInit,
     fetch: verbose ? createDebugFetch(showSecrets) : undefined,
   });
-}
-
-function createDebugFetch(showSecrets: boolean): FetchLike {
-  const isTTY = process.stderr.isTTY ?? false;
-  const fmt = (s: string) => (isTTY ? dim(s) : s);
-
-  return async (url, init) => {
-    const start = performance.now();
-
-    // Request
-    log(fmt(`> ${init?.method ?? "GET"} ${url}`));
-    logHeaders(">", init?.headers, fmt, showSecrets);
-    log(fmt(">"));
-    if (init?.body) {
-      logBody(String(init.body), fmt);
-    }
-
-    const response = await fetch(url, init);
-    const elapsed = Math.round(performance.now() - start);
-
-    // Response
-    log(fmt(`< ${response.status} ${response.statusText} (${elapsed}ms)`));
-    logHeaders("<", response.headers, fmt, showSecrets);
-    log(fmt("<"));
-
-    return response;
-  };
-}
-
-function log(line: string) {
-  logger.writeRaw(line + "\n");
-}
-
-function logHeaders(
-  prefix: string,
-  headers: HeadersInit | Headers | undefined,
-  fmt: (s: string) => string,
-  showSecrets: boolean,
-) {
-  if (!headers) return;
-
-  const format = (key: string, value: string) =>
-    fmt(`${prefix} ${key}: ${showSecrets ? value : maskSensitive(key, value)}`);
-
-  if (headers instanceof Headers) {
-    headers.forEach((value, key) => log(format(key, value)));
-  } else if (Array.isArray(headers)) {
-    for (const [key, value] of headers) {
-      log(format(key, value));
-    }
-  } else {
-    for (const [key, value] of Object.entries(headers)) {
-      log(format(key, value));
-    }
-  }
-}
-
-function logBody(body: string, fmt: (s: string) => string) {
-  try {
-    const formatted = JSON.stringify(JSON.parse(body), null, 2);
-    for (const line of formatted.split("\n")) {
-      log(fmt(line));
-    }
-  } catch {
-    log(fmt(body));
-  }
-}
-
-function maskSensitive(key: string, value: string): string {
-  const lower = key.toLowerCase();
-  if (lower === "authorization" || lower === "cookie" || lower === "set-cookie") {
-    if (value.length <= 12) return value;
-    return value.slice(0, 12) + "...";
-  }
-  return value;
 }

--- a/src/client/manager.ts
+++ b/src/client/manager.ts
@@ -13,7 +13,9 @@ import type {
 import { isStdioServer, isHttpServer } from "../config/schemas.ts";
 import { createStdioTransport } from "./stdio.ts";
 import { createHttpTransport } from "./http.ts";
+import { createSseTransport } from "./sse.ts";
 import { McpOAuthProvider } from "./oauth.ts";
+import { logger } from "../output/logger.ts";
 
 export interface ToolWithServer {
   server: string;
@@ -102,8 +104,35 @@ export class ServerManager {
       const transport = this.createTransport(serverName, config);
       this.transports.set(serverName, transport);
 
-      const client = new Client({ name: pkg.name, version: pkg.version });
-      await this.withTimeout(client.connect(transport), `connect(${serverName})`);
+      let client = new Client({ name: pkg.name, version: pkg.version });
+      try {
+        await this.withTimeout(client.connect(transport), `connect(${serverName})`);
+      } catch (err) {
+        // Auto-fallback: if no explicit transport was set on an HTTP server,
+        // retry with the legacy SSE transport
+        if (isHttpServer(config) && !config.transport) {
+          if (this.verbose) {
+            logger.writeRaw(`Streamable HTTP failed for "${serverName}", trying SSE…\n`);
+          }
+          try {
+            await transport.close?.();
+          } catch {
+            // ignore close errors
+          }
+          const provider = this.getOrCreateOAuthProvider(serverName);
+          const sseTransport = createSseTransport(
+            config,
+            provider.isComplete() ? provider : undefined,
+            this.verbose,
+            this.showSecrets,
+          );
+          this.transports.set(serverName, sseTransport);
+          client = new Client({ name: pkg.name, version: pkg.version });
+          await this.withTimeout(client.connect(sseTransport), `connect-sse(${serverName})`);
+        } else {
+          throw err;
+        }
+      }
       this.clients.set(serverName, client);
       this.connecting.delete(serverName);
 
@@ -140,12 +169,14 @@ export class ServerManager {
       // auto-trigger the browser OAuth flow on 401, which fails because
       // there's no callback server running. Users must run `mcpcli auth <server>` first.
       const provider = this.getOrCreateOAuthProvider(serverName);
-      return createHttpTransport(
-        config,
-        provider.isComplete() ? provider : undefined,
-        this.verbose,
-        this.showSecrets,
-      );
+      const authProvider = provider.isComplete() ? provider : undefined;
+
+      if (config.transport === "sse") {
+        return createSseTransport(config, authProvider, this.verbose, this.showSecrets);
+      }
+      // Default (including explicit "streamable-http") uses Streamable HTTP.
+      // When no transport is set, getClient() will auto-fallback to SSE on failure.
+      return createHttpTransport(config, authProvider, this.verbose, this.showSecrets);
     }
     throw new Error("Invalid server config");
   }

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -1,0 +1,17 @@
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { HttpServerConfig } from "../config/schemas.ts";
+import { createDebugFetch } from "./debug-fetch.ts";
+
+export function createSseTransport(
+  config: HttpServerConfig,
+  authProvider?: OAuthClientProvider,
+  verbose = false,
+  showSecrets = false,
+): SSEClientTransport {
+  return new SSEClientTransport(new URL(config.url), {
+    authProvider,
+    requestInit: config.headers ? { headers: config.headers } : undefined,
+    fetch: verbose ? createDebugFetch(showSecrets) : undefined,
+  });
+}

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -14,6 +14,7 @@ export function registerAddCommand(program: Command) {
     .option("--cwd <dir>", "working directory for the command")
     .option("--url <url>", "server URL (HTTP server)")
     .option("--header <h>", "header in Key:Value format (repeatable)", collect, [])
+    .option("--transport <type>", 'transport for HTTP servers: "sse" or "streamable-http"')
     .option("--allowed-tools <tools>", "comma-separated list of allowed tools")
     .option("--disabled-tools <tools>", "comma-separated list of disabled tools")
     .option("-f, --force", "overwrite if server already exists")
@@ -29,6 +30,7 @@ export function registerAddCommand(program: Command) {
           cwd?: string;
           url?: string;
           header?: string[];
+          transport?: string;
           allowedTools?: string;
           disabledTools?: string;
           force?: boolean;
@@ -62,6 +64,14 @@ export function registerAddCommand(program: Command) {
           config = buildStdioConfig(options);
         } else {
           config = buildHttpConfig(options);
+        }
+
+        if (hasUrl && options.transport) {
+          if (options.transport !== "sse" && options.transport !== "streamable-http") {
+            console.error('--transport must be "sse" or "streamable-http"');
+            process.exit(1);
+          }
+          (config as { transport: string }).transport = options.transport;
         }
 
         // Common options

--- a/src/commands/servers.ts
+++ b/src/commands/servers.ts
@@ -1,7 +1,7 @@
 import { cyan, dim, green, yellow } from "ansis";
 import type { Command } from "commander";
 import { getContext } from "../context.ts";
-import { isStdioServer } from "../config/schemas.ts";
+import { isStdioServer, isHttpServer } from "../config/schemas.ts";
 import { formatError, isInteractive } from "../output/formatter.ts";
 
 export function registerServersCommand(program: Command) {
@@ -19,6 +19,7 @@ export function registerServersCommand(program: Command) {
               servers.map(([name, cfg]) => ({
                 name,
                 type: isStdioServer(cfg) ? "stdio" : "http",
+                ...(isHttpServer(cfg) ? { transport: cfg.transport ?? "http" } : {}),
                 ...(isStdioServer(cfg)
                   ? { command: cfg.command, args: cfg.args ?? [] }
                   : { url: cfg.url }),
@@ -36,13 +37,20 @@ export function registerServersCommand(program: Command) {
         }
 
         const maxName = Math.max(...servers.map(([n]) => n.length));
-        const maxType = 5; // "stdio" / "http "
+
+        function typeLabel(cfg: (typeof servers)[number][1]): string {
+          if (isStdioServer(cfg)) return "stdio";
+          if (isHttpServer(cfg) && cfg.transport === "sse") return "http/sse";
+          if (isHttpServer(cfg) && cfg.transport === "streamable-http") return "http/streamable";
+          return "http";
+        }
+        const maxType = Math.max(...servers.map(([, cfg]) => typeLabel(cfg).length));
 
         for (const [name, cfg] of servers) {
           const n = cyan(name.padEnd(maxName));
           const type = isStdioServer(cfg)
-            ? green("stdio".padEnd(maxType))
-            : yellow("http ".padEnd(maxType));
+            ? green(typeLabel(cfg).padEnd(maxType))
+            : yellow(typeLabel(cfg).padEnd(maxType));
           const detail = isStdioServer(cfg)
             ? dim([cfg.command, ...(cfg.args ?? [])].join(" "))
             : dim(cfg.url);

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -31,6 +31,7 @@ export interface StdioServerConfig {
 export interface HttpServerConfig {
   url: string;
   headers?: Record<string, string>;
+  transport?: "sse" | "streamable-http";
   allowedTools?: string[];
   disabledTools?: string[];
 }
@@ -117,6 +118,13 @@ export function validateServersFile(data: unknown): ServersFile {
     const hasUrl = typeof c.url === "string";
     if (!hasCommand && !hasUrl) {
       throw new Error(`Server "${name}" must have either "command" (stdio) or "url" (http)`);
+    }
+    if (hasUrl && c.transport !== undefined) {
+      if (c.transport !== "sse" && c.transport !== "streamable-http") {
+        throw new Error(
+          `Server "${name}" has invalid transport "${c.transport}" — must be "sse" or "streamable-http"`,
+        );
+      }
     }
   }
 

--- a/test/client/debug-fetch.test.ts
+++ b/test/client/debug-fetch.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "bun:test";
+import { createDebugFetch, maskSensitive } from "../../src/client/debug-fetch.ts";
+
+describe("maskSensitive", () => {
+  test("masks Authorization header values", () => {
+    const result = maskSensitive("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.test");
+    expect(result).toBe("Bearer eyJhb...");
+    expect(result).not.toContain("test");
+  });
+
+  test("masks Cookie header values", () => {
+    const result = maskSensitive("Cookie", "session=abc123def456ghi789");
+    expect(result).toBe("session=abc1...");
+  });
+
+  test("masks Set-Cookie header values", () => {
+    const result = maskSensitive("Set-Cookie", "session=abc123def456ghi789");
+    expect(result).toBe("session=abc1...");
+  });
+
+  test("does not mask short values", () => {
+    const result = maskSensitive("Authorization", "Bearer tok");
+    expect(result).toBe("Bearer tok");
+  });
+
+  test("passes non-sensitive headers through unchanged", () => {
+    expect(maskSensitive("Content-Type", "application/json")).toBe("application/json");
+    expect(maskSensitive("X-Custom", "my-value")).toBe("my-value");
+  });
+});
+
+describe("createDebugFetch", () => {
+  test("returns a function", () => {
+    const debugFetch = createDebugFetch(false);
+    expect(typeof debugFetch).toBe("function");
+  });
+});

--- a/test/client/manager.test.ts
+++ b/test/client/manager.test.ts
@@ -2,7 +2,9 @@ import { describe, test, expect, afterEach, spyOn } from "bun:test";
 import { join } from "path";
 import { ServerManager } from "../../src/client/manager.ts";
 import { McpOAuthProvider } from "../../src/client/oauth.ts";
-import type { ServersFile, AuthFile } from "../../src/config/schemas.ts";
+import type { ServersFile, AuthFile, HttpServerConfig } from "../../src/config/schemas.ts";
+import * as httpModule from "../../src/client/http.ts";
+import * as sseModule from "../../src/client/sse.ts";
 
 const MOCK_SERVER = join(import.meta.dir, "../fixtures/mock-server.ts");
 
@@ -244,6 +246,125 @@ describe("ServerManager with HTTP servers", () => {
     }
 
     expect(refreshSpy).toHaveBeenCalledTimes(1);
+    refreshSpy.mockRestore();
+  });
+
+  test("uses SSE transport when transport is explicitly 'sse'", async () => {
+    const auth: AuthFile = {
+      "sse-server": {
+        tokens: { access_token: "token", token_type: "Bearer" },
+        complete: true,
+      },
+    };
+
+    const sseSpy = spyOn(sseModule, "createSseTransport");
+    const httpSpy = spyOn(httpModule, "createHttpTransport");
+    const refreshSpy = spyOn(McpOAuthProvider.prototype, "refreshIfNeeded").mockResolvedValue(
+      undefined,
+    );
+
+    manager = new ServerManager({
+      servers: {
+        mcpServers: {
+          "sse-server": { url: "http://localhost:19999/sse", transport: "sse" } as HttpServerConfig,
+        },
+      },
+      configDir: "/tmp",
+      auth,
+      timeout: 1000,
+      maxRetries: 0,
+    });
+
+    try {
+      await manager.getClient("sse-server");
+    } catch {
+      // Connection failure expected — no real server
+    }
+
+    expect(sseSpy).toHaveBeenCalledTimes(1);
+    expect(httpSpy).not.toHaveBeenCalled();
+
+    sseSpy.mockRestore();
+    httpSpy.mockRestore();
+    refreshSpy.mockRestore();
+  });
+
+  test("uses Streamable HTTP when transport is explicitly 'streamable-http'", async () => {
+    const auth: AuthFile = {
+      "streamable-server": {
+        tokens: { access_token: "token", token_type: "Bearer" },
+        complete: true,
+      },
+    };
+
+    const sseSpy = spyOn(sseModule, "createSseTransport");
+    const httpSpy = spyOn(httpModule, "createHttpTransport");
+    const refreshSpy = spyOn(McpOAuthProvider.prototype, "refreshIfNeeded").mockResolvedValue(
+      undefined,
+    );
+
+    manager = new ServerManager({
+      servers: {
+        mcpServers: {
+          "streamable-server": {
+            url: "http://localhost:19999/mcp",
+            transport: "streamable-http",
+          } as HttpServerConfig,
+        },
+      },
+      configDir: "/tmp",
+      auth,
+      timeout: 1000,
+      maxRetries: 0,
+    });
+
+    try {
+      await manager.getClient("streamable-server");
+    } catch {
+      // Connection failure expected — no real server
+    }
+
+    expect(httpSpy).toHaveBeenCalledTimes(1);
+    expect(sseSpy).not.toHaveBeenCalled();
+
+    sseSpy.mockRestore();
+    httpSpy.mockRestore();
+    refreshSpy.mockRestore();
+  });
+
+  test("does not fallback to SSE when explicit transport is set", async () => {
+    const auth: AuthFile = {
+      "explicit-server": {
+        tokens: { access_token: "token", token_type: "Bearer" },
+        complete: true,
+      },
+    };
+
+    const sseSpy = spyOn(sseModule, "createSseTransport");
+    const refreshSpy = spyOn(McpOAuthProvider.prototype, "refreshIfNeeded").mockResolvedValue(
+      undefined,
+    );
+
+    manager = new ServerManager({
+      servers: {
+        mcpServers: {
+          "explicit-server": {
+            url: "http://localhost:19999/mcp",
+            transport: "streamable-http",
+          } as HttpServerConfig,
+        },
+      },
+      configDir: "/tmp",
+      auth,
+      timeout: 1000,
+      maxRetries: 0,
+    });
+
+    await expect(manager.getClient("explicit-server")).rejects.toThrow();
+    // SSE should NOT be attempted as fallback since transport was explicitly set
+    expect(sseSpy).not.toHaveBeenCalled();
+
+    sseSpy.mockRestore();
     refreshSpy.mockRestore();
   });
 });

--- a/test/client/sse.test.ts
+++ b/test/client/sse.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { createSseTransport } from "../../src/client/sse.ts";
+import type { HttpServerConfig } from "../../src/config/schemas.ts";
+
+describe("createSseTransport", () => {
+  test("returns an SSEClientTransport instance", () => {
+    const config: HttpServerConfig = { url: "https://example.com/sse" };
+    const transport = createSseTransport(config);
+    expect(transport).toBeInstanceOf(SSEClientTransport);
+  });
+
+  test("accepts custom headers", () => {
+    const config: HttpServerConfig = {
+      url: "https://example.com/sse",
+      headers: { Authorization: "Bearer tok123" },
+    };
+    const transport = createSseTransport(config);
+    expect(transport).toBeInstanceOf(SSEClientTransport);
+  });
+
+  test("accepts an auth provider", () => {
+    const config: HttpServerConfig = { url: "https://example.com/sse" };
+    const fakeProvider = {
+      get redirectUrl() {
+        return "http://localhost/callback";
+      },
+      get clientMetadata() {
+        return { redirect_uris: ["http://localhost/callback"] };
+      },
+      clientInformation: () => Promise.resolve({ client_id: "test" }),
+      tokens: () => Promise.resolve({ access_token: "tok", token_type: "Bearer" }),
+      saveTokens: () => Promise.resolve(),
+      saveClientInformation: () => Promise.resolve(),
+    };
+    const transport = createSseTransport(config, fakeProvider as any);
+    expect(transport).toBeInstanceOf(SSEClientTransport);
+  });
+
+  test("accepts verbose mode without errors", () => {
+    const config: HttpServerConfig = { url: "https://example.com/sse" };
+    const transport = createSseTransport(config, undefined, true, false);
+    expect(transport).toBeInstanceOf(SSEClientTransport);
+  });
+});

--- a/test/commands/add-remove.test.ts
+++ b/test/commands/add-remove.test.ts
@@ -152,6 +152,83 @@ describe("mcpcli add", () => {
     expect(servers.mcpServers["dupe"].command).toBe("cat");
   });
 
+  test("adds an http server with --transport sse", async () => {
+    const { exitCode } = await run([
+      "-c",
+      tmpDir,
+      "add",
+      "my-sse",
+      "--url",
+      "https://example.com/sse",
+      "--transport",
+      "sse",
+      "--no-index",
+    ]);
+    expect(exitCode).toBe(0);
+
+    const servers = await Bun.file(join(tmpDir, "servers.json")).json();
+    expect(servers.mcpServers["my-sse"]).toEqual({
+      url: "https://example.com/sse",
+      transport: "sse",
+    });
+  });
+
+  test("adds an http server with --transport streamable-http", async () => {
+    const { exitCode } = await run([
+      "-c",
+      tmpDir,
+      "add",
+      "my-streamable",
+      "--url",
+      "https://example.com/mcp",
+      "--transport",
+      "streamable-http",
+      "--no-index",
+    ]);
+    expect(exitCode).toBe(0);
+
+    const servers = await Bun.file(join(tmpDir, "servers.json")).json();
+    expect(servers.mcpServers["my-streamable"]).toEqual({
+      url: "https://example.com/mcp",
+      transport: "streamable-http",
+    });
+  });
+
+  test("adds an http server without --transport (auto-detect)", async () => {
+    const { exitCode } = await run([
+      "-c",
+      tmpDir,
+      "add",
+      "my-auto",
+      "--url",
+      "https://example.com/mcp",
+      "--no-index",
+    ]);
+    expect(exitCode).toBe(0);
+
+    const servers = await Bun.file(join(tmpDir, "servers.json")).json();
+    expect(servers.mcpServers["my-auto"]).toEqual({
+      url: "https://example.com/mcp",
+    });
+    expect(servers.mcpServers["my-auto"].transport).toBeUndefined();
+  });
+
+  test("errors on invalid --transport value", async () => {
+    const { exitCode, stderr } = await run([
+      "-c",
+      tmpDir,
+      "add",
+      "bad-transport",
+      "--url",
+      "https://example.com",
+      "--transport",
+      "websocket",
+      "--no-index",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--transport must be");
+  });
+
   test("errors if neither --command nor --url", async () => {
     const { exitCode, stderr } = await run(["-c", tmpDir, "add", "bad"]);
     expect(exitCode).not.toBe(0);

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -76,6 +76,41 @@ describe("validateServersFile", () => {
     }
   });
 
+  test("accepts valid transport values", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "mcpcli-test-"));
+    try {
+      await Bun.write(
+        join(tmpDir, "servers.json"),
+        JSON.stringify({
+          mcpServers: {
+            sse: { url: "https://example.com/sse", transport: "sse" },
+            streamable: { url: "https://example.com/mcp", transport: "streamable-http" },
+            auto: { url: "https://example.com/mcp" },
+          },
+        }),
+      );
+      const config = await loadConfig({ configFlag: tmpDir });
+      expect(Object.keys(config.servers.mcpServers)).toEqual(["sse", "streamable", "auto"]);
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  test("rejects invalid transport value", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "mcpcli-test-"));
+    try {
+      await Bun.write(
+        join(tmpDir, "servers.json"),
+        JSON.stringify({
+          mcpServers: { bad: { url: "https://example.com", transport: "websocket" } },
+        }),
+      );
+      await expect(loadConfig({ configFlag: tmpDir })).rejects.toThrow("invalid transport");
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
   test("rejects server without command or url", async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), "mcpcli-test-"));
     try {


### PR DESCRIPTION
## Summary

Adds support for legacy SSE (Server-Sent Events) MCP transport alongside the existing Stdio and Streamable HTTP transports. Implements auto-fallback behavior: HTTP servers without explicit transport try Streamable HTTP first, then automatically fall back to SSE on connection failure.

## Changes

- New `src/client/sse.ts` — SSEClientTransport factory with auth provider and debug fetch support
- New `src/client/debug-fetch.ts` — Shared debug utilities extracted from http.ts
- Enhanced `src/client/manager.ts` — Transport selection and auto-fallback logic
- Added `--transport` flag to `add` command (sse | streamable-http)
- Updated schema validation and `servers` command to display transport type
- Comprehensive test coverage (19 new tests across 4 test files)
- Version bump to 0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)