### PR TITLE
Add comprehensive end-to-end tests for HTTP MCP transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {
@@ -15,6 +15,7 @@
   "scripts": {
     "dev": "bun run src/cli.ts",
     "test": "bun test",
+    "test:e2e": "bun test test/integration/remote-server.test.ts",
     "lint": "prettier --check .",
     "format": "prettier --write .",
     "build": "bun build --compile --minify --sourcemap ./src/cli.ts --outfile dist/mcpcli"

--- a/src/client/manager.ts
+++ b/src/client/manager.ts
@@ -88,16 +88,23 @@ export class ServerManager {
     }
 
     const connectPromise = (async () => {
-      // Auto-refresh expired OAuth tokens before connecting to HTTP servers
+      // Auto-refresh expired OAuth tokens before connecting to HTTP servers.
+      // Only enforce auth if the server has a partial/incomplete auth entry —
+      // servers that don't require OAuth won't have an auth entry at all.
       if (isHttpServer(config)) {
-        const provider = this.getOrCreateOAuthProvider(serverName);
-        if (!provider.isComplete()) {
-          throw new Error(`Not authenticated with "${serverName}". Run: mcpcli auth ${serverName}`);
-        }
-        try {
-          await provider.refreshIfNeeded(config.url);
-        } catch {
-          // If refresh fails, continue — the transport will send the existing token
+        const hasAuthEntry = !!this.auth[serverName];
+        if (hasAuthEntry) {
+          const provider = this.getOrCreateOAuthProvider(serverName);
+          if (!provider.isComplete()) {
+            throw new Error(
+              `Not authenticated with "${serverName}". Run: mcpcli auth ${serverName}`,
+            );
+          }
+          try {
+            await provider.refreshIfNeeded(config.url);
+          } catch {
+            // If refresh fails, continue — the transport will send the existing token
+          }
         }
       }
 

--- a/test/fixtures/mock-http-server.ts
+++ b/test/fixtures/mock-http-server.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env bun
+
+/**
+ * Minimal MCP server over Streamable HTTP for testing.
+ * Starts on a random port and prints the URL to stdout for test discovery.
+ * Implements the same tools/resources/prompts as mock-server.ts but over HTTP.
+ */
+
+const tools = [
+  {
+    name: "echo",
+    description: "Echoes back the input",
+    inputSchema: {
+      type: "object",
+      properties: { message: { type: "string", description: "Message to echo" } },
+      required: ["message"],
+    },
+  },
+  {
+    name: "add",
+    description: "Adds two numbers",
+    inputSchema: {
+      type: "object",
+      properties: { a: { type: "number" }, b: { type: "number" } },
+      required: ["a", "b"],
+    },
+  },
+  {
+    name: "noop",
+    description: "A tool that takes no arguments",
+    inputSchema: { type: "object", properties: {} },
+  },
+];
+
+const resources = [
+  {
+    uri: "file:///hello.txt",
+    name: "Hello File",
+    description: "A simple greeting file",
+    mimeType: "text/plain",
+  },
+];
+
+const prompts = [
+  {
+    name: "greet",
+    description: "Generate a greeting message",
+    arguments: [{ name: "name", description: "Name to greet", required: true }],
+  },
+];
+
+// Track active SSE sessions for session-based routing
+const sessions = new Map<string, boolean>();
+
+function handleJsonRpc(msg: { jsonrpc: string; id?: number; method: string; params?: unknown }) {
+  if (msg.method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id: msg.id,
+      result: {
+        protocolVersion: "2025-03-26",
+        capabilities: { tools: {}, resources: {}, prompts: {} },
+        serverInfo: { name: "mock-http-server", version: "1.0.0" },
+      },
+    };
+  }
+
+  if (msg.method === "notifications/initialized") {
+    return null; // No response for notifications
+  }
+
+  if (msg.method === "tools/list") {
+    return { jsonrpc: "2.0", id: msg.id, result: { tools } };
+  }
+
+  if (msg.method === "tools/call") {
+    const params = msg.params as { name: string; arguments?: Record<string, unknown> };
+    if (params.name === "echo") {
+      return {
+        jsonrpc: "2.0",
+        id: msg.id,
+        result: { content: [{ type: "text", text: String(params.arguments?.message ?? "") }] },
+      };
+    }
+    if (params.name === "add") {
+      const a = Number(params.arguments?.a ?? 0);
+      const b = Number(params.arguments?.b ?? 0);
+      return {
+        jsonrpc: "2.0",
+        id: msg.id,
+        result: { content: [{ type: "text", text: String(a + b) }] },
+      };
+    }
+    if (params.name === "noop") {
+      return { jsonrpc: "2.0", id: msg.id, result: { content: [{ type: "text", text: "ok" }] } };
+    }
+    return {
+      jsonrpc: "2.0",
+      id: msg.id,
+      result: { content: [{ type: "text", text: `unknown tool: ${params.name}` }], isError: true },
+    };
+  }
+
+  if (msg.method === "resources/list") {
+    return { jsonrpc: "2.0", id: msg.id, result: { resources } };
+  }
+
+  if (msg.method === "resources/read") {
+    const params = msg.params as { uri: string };
+    if (params.uri === "file:///hello.txt") {
+      return {
+        jsonrpc: "2.0",
+        id: msg.id,
+        result: { contents: [{ uri: params.uri, mimeType: "text/plain", text: "Hello, World!" }] },
+      };
+    }
+    return {
+      jsonrpc: "2.0",
+      id: msg.id,
+      error: { code: -32602, message: `Resource not found: ${params.uri}` },
+    };
+  }
+
+  if (msg.method === "prompts/list") {
+    return { jsonrpc: "2.0", id: msg.id, result: { prompts } };
+  }
+
+  if (msg.method === "prompts/get") {
+    const params = msg.params as { name: string; arguments?: Record<string, string> };
+    if (params.name === "greet") {
+      const name = params.arguments?.name ?? "World";
+      return {
+        jsonrpc: "2.0",
+        id: msg.id,
+        result: {
+          description: "A greeting prompt",
+          messages: [{ role: "user", content: { type: "text", text: `Hello, ${name}!` } }],
+        },
+      };
+    }
+    return {
+      jsonrpc: "2.0",
+      id: msg.id,
+      error: { code: -32602, message: `Prompt not found: ${params.name}` },
+    };
+  }
+
+  if (msg.method === "ping") {
+    return { jsonrpc: "2.0", id: msg.id, result: {} };
+  }
+
+  return {
+    jsonrpc: "2.0",
+    id: msg.id,
+    error: { code: -32601, message: `Method not found: ${msg.method}` },
+  };
+}
+
+function generateSessionId(): string {
+  return crypto.randomUUID();
+}
+
+const server = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    // Only handle /mcp endpoint
+    if (url.pathname !== "/mcp") {
+      return new Response("Not found", { status: 404 });
+    }
+
+    if (req.method === "POST") {
+      const body = await req.json();
+      const response = handleJsonRpc(body);
+
+      // Assign session ID on initialize
+      let sessionId = req.headers.get("mcp-session-id");
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+      if (body.method === "initialize") {
+        sessionId = generateSessionId();
+        sessions.set(sessionId, true);
+        headers["mcp-session-id"] = sessionId;
+      } else if (sessionId) {
+        headers["mcp-session-id"] = sessionId;
+      }
+
+      // Notifications don't get a response body
+      if (response === null) {
+        return new Response(null, { status: 204, headers });
+      }
+
+      return new Response(JSON.stringify(response), { status: 200, headers });
+    }
+
+    if (req.method === "DELETE") {
+      // Session termination
+      const sessionId = req.headers.get("mcp-session-id");
+      if (sessionId) {
+        sessions.delete(sessionId);
+      }
+      return new Response(null, { status: 204 });
+    }
+
+    return new Response("Method not allowed", { status: 405 });
+  },
+});
+
+// Print the URL so the test can discover the port
+console.log(`http://localhost:${server.port}/mcp`);

--- a/test/integration/remote-server.test.ts
+++ b/test/integration/remote-server.test.ts
@@ -1,0 +1,257 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { join } from "path";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+
+const CLI = join(import.meta.dir, "../../src/cli.ts");
+const HTTP_SERVER = join(import.meta.dir, "../fixtures/mock-http-server.ts");
+const TIMEOUT = 30_000;
+
+/**
+ * End-to-end tests that connect to an HTTP MCP server using the
+ * Streamable HTTP transport and exercise core CLI commands.
+ *
+ * A local HTTP MCP server is started before tests and torn down after.
+ * This tests the full HTTP transport path (connection, JSON-RPC over HTTP,
+ * session management) without requiring external network access.
+ */
+
+let serverProc: ReturnType<typeof Bun.spawn>;
+let configDir: string;
+
+function run(...args: string[]) {
+  return Bun.spawn(["bun", "run", CLI, "-c", configDir, "--json", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: join(import.meta.dir, "../.."),
+  });
+}
+
+async function runAndParse<T = unknown>(...args: string[]): Promise<T> {
+  const proc = run(...args);
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`mcpcli exited with ${exitCode}: ${stderr}\n${stdout}`);
+  }
+  return JSON.parse(stdout) as T;
+}
+
+beforeAll(async () => {
+  // Start the HTTP MCP server
+  serverProc = Bun.spawn(["bun", "run", HTTP_SERVER], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Read the server URL from stdout (first line)
+  const reader = serverProc.stdout.getReader();
+  const { value } = await reader.read();
+  reader.releaseLock();
+  const serverUrl = new TextDecoder().decode(value).trim();
+
+  // Create a temp config directory pointing to the local HTTP server
+  configDir = mkdtempSync(join(tmpdir(), "mcpcli-e2e-"));
+  writeFileSync(
+    join(configDir, "servers.json"),
+    JSON.stringify({
+      mcpServers: {
+        remote: { url: serverUrl },
+      },
+    }),
+  );
+}, TIMEOUT);
+
+afterAll(async () => {
+  serverProc?.kill();
+  if (configDir) {
+    rmSync(configDir, { recursive: true, force: true });
+  }
+});
+
+interface PingResult {
+  server: string;
+  success: boolean;
+  latencyMs?: number;
+  error?: string;
+}
+interface UnifiedItem {
+  server: string;
+  type: string;
+  name: string;
+  description?: string;
+}
+interface ServerTools {
+  server: string;
+  tools: { name: string; description?: string }[];
+}
+interface ToolSchema {
+  server: string;
+  tool: string;
+  inputSchema: { type: string; properties?: Record<string, unknown> };
+}
+interface CallResult {
+  content: { type: string; text: string }[];
+}
+interface ServerResources {
+  server: string;
+  resources: { uri: string; name: string; description?: string }[];
+}
+interface ServerPrompts {
+  server: string;
+  prompts: { name: string; description?: string }[];
+}
+
+describe("HTTP MCP server end-to-end", () => {
+  test(
+    "pings the server successfully",
+    async () => {
+      const results = await runAndParse<PingResult[]>("ping");
+      expect(results).toBeInstanceOf(Array);
+      expect(results.length).toBe(1);
+      expect(results[0]!.server).toBe("remote");
+      expect(results[0]!.success).toBe(true);
+      expect(results[0]!.latencyMs).toBeGreaterThan(0);
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "lists all tools, resources, and prompts",
+    async () => {
+      const items = await runAndParse<UnifiedItem[]>();
+      expect(items).toBeInstanceOf(Array);
+
+      const tools = items.filter((i) => i.type === "tool");
+      expect(tools.length).toBeGreaterThan(0);
+
+      const toolNames = tools.map((t) => t.name);
+      expect(toolNames).toContain("echo");
+      expect(toolNames).toContain("add");
+
+      const resources = items.filter((i) => i.type === "resource");
+      expect(resources.length).toBeGreaterThan(0);
+
+      const prompts = items.filter((i) => i.type === "prompt");
+      expect(prompts.length).toBeGreaterThan(0);
+
+      for (const item of items) {
+        expect(item.server).toBe("remote");
+      }
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "lists items with descriptions",
+    async () => {
+      const items = await runAndParse<UnifiedItem[]>("-d");
+      const echo = items.find((i) => i.type === "tool" && i.name === "echo");
+      expect(echo).toBeDefined();
+      expect(echo!.description!.length).toBeGreaterThan(0);
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "inspects server to list its tools",
+    async () => {
+      const result = await runAndParse<ServerTools>("info", "remote");
+      expect(result.server).toBe("remote");
+      expect(result.tools.length).toBeGreaterThan(0);
+      const toolNames = result.tools.map((t) => t.name);
+      expect(toolNames).toContain("echo");
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "inspects the echo tool schema",
+    async () => {
+      const result = await runAndParse<ToolSchema>("info", "remote", "echo");
+      expect(result.server).toBe("remote");
+      expect(result.tool).toBe("echo");
+      expect(result.inputSchema).toBeDefined();
+      expect(result.inputSchema.type).toBe("object");
+      expect(result.inputSchema.properties).toHaveProperty("message");
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "executes the echo tool",
+    async () => {
+      const result = await runAndParse<CallResult>(
+        "exec",
+        "remote",
+        "echo",
+        '{"message":"hello from mcpcli"}',
+      );
+      expect(result.content).toBeInstanceOf(Array);
+      expect(result.content.length).toBeGreaterThanOrEqual(1);
+      expect(result.content[0]!.type).toBe("text");
+      expect(result.content[0]!.text).toContain("hello from mcpcli");
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "executes the add tool",
+    async () => {
+      const result = await runAndParse<CallResult>("exec", "remote", "add", '{"a":2,"b":3}');
+      expect(result.content).toBeInstanceOf(Array);
+      expect(String(result.content[0]!.text)).toBe("5");
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "validates tool input and rejects missing required fields",
+    async () => {
+      const proc = run("exec", "remote", "echo", "{}");
+      const exitCode = await proc.exited;
+      const stderr = await new Response(proc.stderr).text();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("message");
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "validates tool input and rejects wrong types",
+    async () => {
+      const proc = run("exec", "remote", "add", '{"a":"not a number","b":1}');
+      const exitCode = await proc.exited;
+      const stderr = await new Response(proc.stderr).text();
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("a");
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "lists resources for the server",
+    async () => {
+      const result = await runAndParse<ServerResources>("resource", "remote");
+      expect(result.server).toBe("remote");
+      expect(result.resources).toBeInstanceOf(Array);
+      expect(result.resources.length).toBeGreaterThan(0);
+      expect(result.resources[0]).toHaveProperty("uri");
+      expect(result.resources[0]).toHaveProperty("name");
+    },
+    { timeout: TIMEOUT },
+  );
+
+  test(
+    "lists prompts for the server",
+    async () => {
+      const result = await runAndParse<ServerPrompts>("prompt", "remote");
+      expect(result.server).toBe("remote");
+      expect(result.prompts).toBeInstanceOf(Array);
+      expect(result.prompts.length).toBeGreaterThan(0);
+      expect(result.prompts[0]).toHaveProperty("name");
+    },
+    { timeout: TIMEOUT },
+  );
+});


### PR DESCRIPTION
## Summary

- **Local HTTP MCP server fixture** (`mock-http-server.ts`) implementing Streamable HTTP protocol with tools, resources, and prompts
- **11 end-to-end tests** covering ping, list (with descriptions), info (server + tool schema), exec (with validation), resources, and prompts
- **Bug fix**: CLI now allows no-auth HTTP servers to connect without requiring OAuth authentication. Auth is only enforced if the server has an existing partial auth entry.
- Version bumped to 0.8.1; added `test:e2e` npm script

## Test Plan

- Run `bun test test/integration/remote-server.test.ts` to verify e2e tests pass
- Run `bun test` to verify all 185 tests (including 11 new e2e tests) pass
- CI will automatically run these tests on push/PR

🤖 Generated with Claude Code