### PR TITLE
Sync README with CLI — document missing flags and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ mcpcli remove my-api --dry-run
 | `--allowed-tools <t1,t2>`  | Comma-separated allowed tool patterns  |
 | `--disabled-tools <t1,t2>` | Comma-separated disabled tool patterns |
 | `-f, --force`              | Overwrite if server already exists     |
+| `--no-auth`                | Skip automatic OAuth after adding      |
+| `--no-index`               | Skip rebuilding the search index       |
 
 **`remove` options:**
 
@@ -276,6 +278,9 @@ mcpcli auth github -s
 
 # Force re-authentication
 mcpcli auth github -r
+
+# Authenticate without rebuilding the search index
+mcpcli auth github --no-index
 ```
 
 The OAuth flow:
@@ -350,7 +355,7 @@ mcpcli -v exec arcade Gmail_WhoAmI
 mcpcli -v exec arcade Gmail_WhoAmI | jq .
 
 # Show full auth tokens (unmasked)
-mcpcli -v -S call arcade Gmail_WhoAmI
+mcpcli -v -S exec arcade Gmail_WhoAmI
 ```
 
 The `>` / `<` convention matches curl — `>` for request, `<` for response. The JSON-RPC body is shown between the request headers and response, without a prefix. Timing is displayed on the response status line.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Document the --no-auth and --no-index flags for the add and auth commands that were missing from the README. Fix typo in verbose mode example (call → exec).