### PR TITLE
Fix canonical URL resolution stripping endpoint path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpcli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/client/oauth.ts
+++ b/src/client/oauth.ts
@@ -257,7 +257,16 @@ export async function resolveResourceUrl(serverUrl: string): Promise<string> {
     const info = await discoverOAuthServerInfo(serverUrl);
     const canonical = info.resourceMetadata?.resource;
     if (canonical && canonical !== serverUrl) {
-      return canonical;
+      // Preserve the path/query/hash from the original URL — the canonical URL
+      // from OAuth resource metadata identifies the origin (scheme + host + port),
+      // not the endpoint path (e.g. /mcp).
+      const orig = new URL(serverUrl);
+      const canon = new URL(canonical);
+      canon.pathname = orig.pathname;
+      canon.search = orig.search;
+      canon.hash = orig.hash;
+      const merged = canon.toString();
+      return merged === serverUrl ? serverUrl : merged;
     }
   } catch {
     // OAuth discovery not available — use original URL


### PR DESCRIPTION
## Summary
- `resolveResourceUrl()` was replacing the entire URL with the OAuth canonical URL, which only contains the origin — stripping endpoint paths like `/mcp`
- This caused 404s when connecting to servers like Cloudflare (`https://mcp.cloudflare.com/mcp` → `https://mcp.cloudflare.com`)
- Now preserves path/query/hash from the original URL, only adopting the origin from canonical

## Test plan
- [x] `bun test` — all 185 tests pass
- [ ] Manual: `mcpcli add cloudflare --url https://mcp.cloudflare.com/mcp --transport sse --force -v` should preserve `/mcp` in stored URL and GET requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)