### PR TITLE
Refactor: DRY up codebase with shared helpers and constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -1,25 +1,6 @@
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import type { HttpServerConfig } from "../config/schemas.ts";
-import pkg from "../../package.json";
-import { createDebugFetch } from "./debug-fetch.ts";
+import { buildTransportInit, type TransportDeps } from "./transport-options.ts";
 
-export function createHttpTransport(
-  config: HttpServerConfig,
-  authProvider?: OAuthClientProvider,
-  verbose = false,
-  showSecrets = false,
-): StreamableHTTPClientTransport {
-  const requestInit: RequestInit = {};
-  const userAgent = `${pkg.name}/${pkg.version}`;
-  requestInit.headers = {
-    "User-Agent": userAgent,
-    ...config.headers,
-  };
-
-  return new StreamableHTTPClientTransport(new URL(config.url), {
-    authProvider,
-    requestInit,
-    fetch: verbose ? createDebugFetch(showSecrets) : undefined,
-  });
+export function createHttpTransport(deps: TransportDeps): StreamableHTTPClientTransport {
+  return new StreamableHTTPClientTransport(new URL(deps.config.url), buildTransportInit(deps));
 }

--- a/src/client/manager.ts
+++ b/src/client/manager.ts
@@ -34,18 +34,19 @@ import { McpOAuthProvider } from "./oauth.ts";
 import { logger } from "../output/logger.ts";
 import { wrapTransportWithTrace } from "./trace.ts";
 
-export interface ToolWithServer {
+interface WithServer {
   server: string;
+}
+
+export interface ToolWithServer extends WithServer {
   tool: Tool;
 }
 
-export interface ResourceWithServer {
-  server: string;
+export interface ResourceWithServer extends WithServer {
   resource: Resource;
 }
 
-export interface PromptWithServer {
-  server: string;
+export interface PromptWithServer extends WithServer {
   prompt: Prompt;
 }
 
@@ -160,12 +161,12 @@ export class ServerManager {
             // ignore close errors
           }
           const provider = this.getOrCreateOAuthProvider(serverName);
-          const rawSseTransport = createSseTransport(
+          const rawSseTransport = createSseTransport({
             config,
-            provider.isComplete() ? provider : undefined,
-            this.verbose,
-            this.showSecrets,
-          );
+            authProvider: provider.isComplete() ? provider : undefined,
+            verbose: this.verbose,
+            showSecrets: this.showSecrets,
+          });
           const sseTransport = this.verbose
             ? wrapTransportWithTrace(rawSseTransport, { json: this.json, serverName })
             : rawSseTransport;
@@ -245,11 +246,21 @@ export class ServerManager {
       const authProvider = provider.isComplete() ? provider : undefined;
 
       if (config.transport === "sse") {
-        return createSseTransport(config, authProvider, this.verbose, this.showSecrets);
+        return createSseTransport({
+          config,
+          authProvider,
+          verbose: this.verbose,
+          showSecrets: this.showSecrets,
+        });
       }
       // Default (including explicit "streamable-http") uses Streamable HTTP.
       // When no transport is set, getClient() will auto-fallback to SSE on failure.
-      return createHttpTransport(config, authProvider, this.verbose, this.showSecrets);
+      return createHttpTransport({
+        config,
+        authProvider,
+        verbose: this.verbose,
+        showSecrets: this.showSecrets,
+      });
     }
     throw new Error("Invalid server config");
   }
@@ -322,18 +333,29 @@ export class ServerManager {
     throw lastError;
   }
 
-  /** List tools for a single server, applying allowedTools/disabledTools filters */
-  async listTools(serverName: string): Promise<Tool[]> {
+  /** Get client, call method with timeout, wrapped in retry logic */
+  private async callWithResilience<T>(
+    serverName: string,
+    label: string,
+    fn: (client: Client) => Promise<T>,
+  ): Promise<T> {
     return this.withRetry(
       async () => {
         const client = await this.getClient(serverName);
-        const result = await this.withTimeout(client.listTools(), `listTools(${serverName})`);
-        const config = this.servers.mcpServers[serverName]!;
-        return filterTools(result.tools, config.allowedTools, config.disabledTools);
+        return this.withTimeout(fn(client), label);
       },
-      `listTools(${serverName})`,
+      label,
       serverName,
     );
+  }
+
+  /** List tools for a single server, applying allowedTools/disabledTools filters */
+  async listTools(serverName: string): Promise<Tool[]> {
+    return this.callWithResilience(serverName, `listTools(${serverName})`, async (client) => {
+      const result = await client.listTools();
+      const config = this.servers.mcpServers[serverName]!;
+      return filterTools(result.tools, config.allowedTools, config.disabledTools);
+    });
   }
 
   /** List tools across all configured servers */
@@ -351,16 +373,8 @@ export class ServerManager {
     toolName: string,
     args: Record<string, unknown> = {},
   ): Promise<unknown> {
-    return this.withRetry(
-      async () => {
-        const client = await this.getClient(serverName);
-        return this.withTimeout(
-          client.callTool({ name: toolName, arguments: args }),
-          `callTool(${serverName}/${toolName})`,
-        );
-      },
-      `callTool(${serverName}/${toolName})`,
-      serverName,
+    return this.callWithResilience(serverName, `callTool(${serverName}/${toolName})`, (client) =>
+      client.callTool({ name: toolName, arguments: args }),
     );
   }
 
@@ -382,18 +396,10 @@ export class ServerManager {
 
   /** List resources for a single server */
   async listResources(serverName: string): Promise<Resource[]> {
-    return this.withRetry(
-      async () => {
-        const client = await this.getClient(serverName);
-        const result = await this.withTimeout(
-          client.listResources(),
-          `listResources(${serverName})`,
-        );
-        return result.resources;
-      },
-      `listResources(${serverName})`,
-      serverName,
-    );
+    return this.callWithResilience(serverName, `listResources(${serverName})`, async (client) => {
+      const result = await client.listResources();
+      return result.resources;
+    });
   }
 
   /** List resources across all configured servers (skips servers without resources capability) */
@@ -409,27 +415,17 @@ export class ServerManager {
 
   /** Read a specific resource by URI */
   async readResource(serverName: string, uri: string): Promise<unknown> {
-    return this.withRetry(
-      async () => {
-        const client = await this.getClient(serverName);
-        return this.withTimeout(client.readResource({ uri }), `readResource(${serverName}/${uri})`);
-      },
-      `readResource(${serverName}/${uri})`,
-      serverName,
+    return this.callWithResilience(serverName, `readResource(${serverName}/${uri})`, (client) =>
+      client.readResource({ uri }),
     );
   }
 
   /** List prompts for a single server */
   async listPrompts(serverName: string): Promise<Prompt[]> {
-    return this.withRetry(
-      async () => {
-        const client = await this.getClient(serverName);
-        const result = await this.withTimeout(client.listPrompts(), `listPrompts(${serverName})`);
-        return result.prompts;
-      },
-      `listPrompts(${serverName})`,
-      serverName,
-    );
+    return this.callWithResilience(serverName, `listPrompts(${serverName})`, async (client) => {
+      const result = await client.listPrompts();
+      return result.prompts;
+    });
   }
 
   /** List prompts across all configured servers (skips servers without prompts capability) */
@@ -449,16 +445,8 @@ export class ServerManager {
     name: string,
     args?: Record<string, string>,
   ): Promise<unknown> {
-    return this.withRetry(
-      async () => {
-        const client = await this.getClient(serverName);
-        return this.withTimeout(
-          client.getPrompt({ name, arguments: args }),
-          `getPrompt(${serverName}/${name})`,
-        );
-      },
-      `getPrompt(${serverName}/${name})`,
-      serverName,
+    return this.callWithResilience(serverName, `getPrompt(${serverName}/${name})`, (client) =>
+      client.getPrompt({ name, arguments: args }),
     );
   }
 

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -1,17 +1,6 @@
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import type { HttpServerConfig } from "../config/schemas.ts";
-import { createDebugFetch } from "./debug-fetch.ts";
+import { buildTransportInit, type TransportDeps } from "./transport-options.ts";
 
-export function createSseTransport(
-  config: HttpServerConfig,
-  authProvider?: OAuthClientProvider,
-  verbose = false,
-  showSecrets = false,
-): SSEClientTransport {
-  return new SSEClientTransport(new URL(config.url), {
-    authProvider,
-    requestInit: config.headers ? { headers: config.headers } : undefined,
-    fetch: verbose ? createDebugFetch(showSecrets) : undefined,
-  });
+export function createSseTransport(deps: TransportDeps): SSEClientTransport {
+  return new SSEClientTransport(new URL(deps.config.url), buildTransportInit(deps));
 }

--- a/src/client/transport-options.ts
+++ b/src/client/transport-options.ts
@@ -1,0 +1,31 @@
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { HttpServerConfig } from "../config/schemas.ts";
+import { createDebugFetch, type FetchLike } from "./debug-fetch.ts";
+import pkg from "../../package.json";
+
+export interface TransportDeps {
+  config: HttpServerConfig;
+  authProvider?: OAuthClientProvider;
+  verbose?: boolean;
+  showSecrets?: boolean;
+}
+
+/** Build shared transport init options (auth, headers, User-Agent, debug fetch) */
+export function buildTransportInit(deps: TransportDeps): {
+  authProvider?: OAuthClientProvider;
+  requestInit: RequestInit;
+  fetch?: FetchLike;
+} {
+  const { config, authProvider, verbose = false, showSecrets = false } = deps;
+  const userAgent = `${pkg.name}/${pkg.version}`;
+  return {
+    authProvider,
+    requestInit: {
+      headers: {
+        "User-Agent": userAgent,
+        ...config.headers,
+      },
+    },
+    fetch: verbose ? createDebugFetch(showSecrets) : undefined,
+  };
+}

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -10,6 +10,7 @@ import {
 import { logger } from "../output/logger.ts";
 import { validateToolInput } from "../validation/schema.ts";
 import { parseJsonArgs, readStdin } from "../lib/input.ts";
+import { DEFAULTS } from "../constants.ts";
 
 export function registerExecCommand(program: Command) {
   program
@@ -17,7 +18,7 @@ export function registerExecCommand(program: Command) {
     .description("execute a tool (omit tool name to list available tools)")
     .option("-f, --file <path>", "read JSON args from a file")
     .option("--no-wait", "return task handle immediately without waiting for completion")
-    .option("--ttl <ms>", "task TTL in milliseconds", "60000")
+    .option("--ttl <ms>", "task TTL in milliseconds", String(DEFAULTS.TASK_TTL_MS))
     .action(
       async (
         server: string,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,32 +4,27 @@ import { getContext } from "../context.ts";
 import { buildSearchIndex } from "../search/indexer.ts";
 import { getStaleServers } from "../search/staleness.ts";
 import { saveSearchIndex } from "../config/loader.ts";
-import { formatError } from "../output/formatter.ts";
 import { logger } from "../output/logger.ts";
+import { withCommand } from "./with-command.ts";
 
 /** Run the search index build. Reusable from other commands (e.g. add). */
 export async function runIndex(program: Command): Promise<void> {
-  const { config, manager, formatOptions } = await getContext(program);
-  const spinner = logger.startSpinner("Connecting to servers...", formatOptions);
+  await withCommand(
+    program,
+    { spinnerText: "Connecting to servers...", errorLabel: "Indexing failed" },
+    async ({ config, manager, spinner }) => {
+      const start = performance.now();
+      const index = await buildSearchIndex(manager, (progress) => {
+        spinner.update(`Indexing ${progress.current}/${progress.total}: ${progress.tool}`);
+      });
+      const elapsed = ((performance.now() - start) / 1000).toFixed(1);
 
-  try {
-    const start = performance.now();
-    const index = await buildSearchIndex(manager, (progress) => {
-      spinner.update(`Indexing ${progress.current}/${progress.total}: ${progress.tool}`);
-    });
-    const elapsed = ((performance.now() - start) / 1000).toFixed(1);
+      await saveSearchIndex(config.configDir, index);
+      spinner.success(`Indexed ${index.tools.length} tools in ${elapsed}s`);
 
-    await saveSearchIndex(config.configDir, index);
-    spinner.success(`Indexed ${index.tools.length} tools in ${elapsed}s`);
-
-    logger.info(`Saved to ${config.configDir}/search.json`);
-  } catch (err) {
-    spinner.error("Indexing failed");
-    console.error(formatError(String(err), formatOptions));
-    process.exit(1);
-  } finally {
-    await manager.close();
-  }
+      logger.info(`Saved to ${config.configDir}/search.json`);
+    },
+  )();
 }
 
 export function registerIndexCommand(program: Command) {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,63 +1,58 @@
 import type { Command } from "commander";
 import type { Tool, Resource, Prompt } from "../config/schemas.ts";
-import { getContext } from "../context.ts";
 import { formatServerOverview, formatToolSchema, formatError } from "../output/formatter.ts";
-import { logger } from "../output/logger.ts";
+import { withCommand } from "./with-command.ts";
 
 export function registerInfoCommand(program: Command) {
   program
     .command("info <server> [tool]")
     .description("show server overview, or schema for a specific tool")
-    .action(async (server: string, tool: string | undefined) => {
-      const { manager, formatOptions } = await getContext(program);
-      const target = tool ? `${server}/${tool}` : server;
-      const spinner = logger.startSpinner(`Connecting to ${target}...`, formatOptions);
-      try {
-        if (tool) {
-          const toolSchema = await manager.getToolSchema(server, tool);
-          spinner.stop();
-          if (!toolSchema) {
-            console.error(
-              formatError(`Tool "${tool}" not found on server "${server}"`, formatOptions),
+    .action(
+      withCommand(
+        program,
+        { spinnerText: "Connecting..." },
+        async ({ manager, formatOptions, spinner }, server: string, tool?: string) => {
+          const target = tool ? `${server}/${tool}` : server;
+          spinner.update(`Connecting to ${target}...`);
+
+          if (tool) {
+            const toolSchema = await manager.getToolSchema(server, tool);
+            spinner.stop();
+            if (!toolSchema) {
+              console.error(
+                formatError(`Tool "${tool}" not found on server "${server}"`, formatOptions),
+              );
+              process.exit(1);
+            }
+            console.log(formatToolSchema(server, toolSchema, formatOptions));
+          } else {
+            const serverInfo = await manager.getServerInfo(server);
+            const caps = serverInfo.capabilities as Record<string, unknown> | undefined;
+
+            const fetches: [Promise<Tool[]>, Promise<Resource[]>, Promise<Prompt[]>] = [
+              caps?.tools !== undefined ? manager.listTools(server) : Promise.resolve([]),
+              caps?.resources !== undefined ? manager.listResources(server) : Promise.resolve([]),
+              caps?.prompts !== undefined ? manager.listPrompts(server) : Promise.resolve([]),
+            ];
+            const [tools, resources, prompts] = await Promise.all(fetches);
+
+            spinner.stop();
+            console.log(
+              formatServerOverview(
+                {
+                  serverName: server,
+                  version: serverInfo.version,
+                  capabilities: caps,
+                  instructions: serverInfo.instructions,
+                  tools,
+                  resourceCount: resources.length,
+                  promptCount: prompts.length,
+                },
+                formatOptions,
+              ),
             );
-            process.exit(1);
           }
-          console.log(formatToolSchema(server, toolSchema, formatOptions));
-        } else {
-          // Get server info first to check capabilities
-          const serverInfo = await manager.getServerInfo(server);
-          const caps = serverInfo.capabilities as Record<string, unknown> | undefined;
-
-          // Only fetch what the server supports
-          const fetches: [Promise<Tool[]>, Promise<Resource[]>, Promise<Prompt[]>] = [
-            caps?.tools !== undefined ? manager.listTools(server) : Promise.resolve([]),
-            caps?.resources !== undefined ? manager.listResources(server) : Promise.resolve([]),
-            caps?.prompts !== undefined ? manager.listPrompts(server) : Promise.resolve([]),
-          ];
-          const [tools, resources, prompts] = await Promise.all(fetches);
-
-          spinner.stop();
-          console.log(
-            formatServerOverview(
-              {
-                serverName: server,
-                version: serverInfo.version,
-                capabilities: caps,
-                instructions: serverInfo.instructions,
-                tools,
-                resourceCount: resources.length,
-                promptCount: prompts.length,
-              },
-              formatOptions,
-            ),
-          );
-        }
-      } catch (err) {
-        spinner.error(`Failed to connect to ${target}`);
-        console.error(formatError(String(err), formatOptions));
-        process.exit(1);
-      } finally {
-        await manager.close();
-      }
-    });
+        },
+      ),
+    );
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,64 +1,59 @@
 import type { Command } from "commander";
-import { getContext } from "../context.ts";
-import { formatUnifiedList, formatError } from "../output/formatter.ts";
+import { formatUnifiedList } from "../output/formatter.ts";
 import type { UnifiedItem } from "../output/formatter.ts";
-import { logger } from "../output/logger.ts";
+import { withCommand } from "./with-command.ts";
 
 export function registerListCommand(program: Command) {
-  program.action(async () => {
-    const { manager, formatOptions } = await getContext(program);
-    const spinner = logger.startSpinner("Connecting to servers...", formatOptions);
-    try {
-      const [toolsResult, resourcesResult, promptsResult] = await Promise.all([
-        manager.getAllTools(),
-        manager.getAllResources(),
-        manager.getAllPrompts(),
-      ]);
-      spinner.stop();
+  program.action(
+    withCommand(
+      program,
+      { spinnerText: "Connecting to servers...", errorLabel: "Failed to list servers" },
+      async ({ manager, formatOptions, spinner }) => {
+        const [toolsResult, resourcesResult, promptsResult] = await Promise.all([
+          manager.getAllTools(),
+          manager.getAllResources(),
+          manager.getAllPrompts(),
+        ]);
+        spinner.stop();
 
-      const items: UnifiedItem[] = [
-        ...toolsResult.tools.map((t) => ({
-          server: t.server,
-          type: "tool" as const,
-          name: t.tool.name,
-          description: t.tool.description,
-        })),
-        ...resourcesResult.resources.map((r) => ({
-          server: r.server,
-          type: "resource" as const,
-          name: r.resource.uri,
-          description: r.resource.description,
-        })),
-        ...promptsResult.prompts.map((p) => ({
-          server: p.server,
-          type: "prompt" as const,
-          name: p.prompt.name,
-          description: p.prompt.description,
-        })),
-      ];
+        const items: UnifiedItem[] = [
+          ...toolsResult.tools.map((t) => ({
+            server: t.server,
+            type: "tool" as const,
+            name: t.tool.name,
+            description: t.tool.description,
+          })),
+          ...resourcesResult.resources.map((r) => ({
+            server: r.server,
+            type: "resource" as const,
+            name: r.resource.uri,
+            description: r.resource.description,
+          })),
+          ...promptsResult.prompts.map((p) => ({
+            server: p.server,
+            type: "prompt" as const,
+            name: p.prompt.name,
+            description: p.prompt.description,
+          })),
+        ];
 
-      const typeOrder = { tool: 0, resource: 1, prompt: 2 };
-      items.sort((a, b) => {
-        if (a.server !== b.server) return a.server.localeCompare(b.server);
-        if (a.type !== b.type) return typeOrder[a.type] - typeOrder[b.type];
-        return a.name.localeCompare(b.name);
-      });
+        const typeOrder = { tool: 0, resource: 1, prompt: 2 };
+        items.sort((a, b) => {
+          if (a.server !== b.server) return a.server.localeCompare(b.server);
+          if (a.type !== b.type) return typeOrder[a.type] - typeOrder[b.type];
+          return a.name.localeCompare(b.name);
+        });
 
-      const errors = [...toolsResult.errors, ...resourcesResult.errors, ...promptsResult.errors];
-      if (errors.length > 0) {
-        for (const err of errors) {
-          console.error(`"${err.server}": ${err.message}`);
+        const errors = [...toolsResult.errors, ...resourcesResult.errors, ...promptsResult.errors];
+        if (errors.length > 0) {
+          for (const err of errors) {
+            console.error(`"${err.server}": ${err.message}`);
+          }
+          if (items.length > 0) console.log("");
         }
-        if (items.length > 0) console.log("");
-      }
 
-      console.log(formatUnifiedList(items, formatOptions));
-    } catch (err) {
-      spinner.error("Failed to list servers");
-      console.error(formatError(String(err), formatOptions));
-      process.exit(1);
-    } finally {
-      await manager.close();
-    }
-  });
+        console.log(formatUnifiedList(items, formatOptions));
+      },
+    ),
+  );
 }

--- a/src/commands/prompt.ts
+++ b/src/commands/prompt.ts
@@ -1,26 +1,31 @@
 import type { Command } from "commander";
-import { getContext } from "../context.ts";
 import {
   formatPromptList,
   formatServerPrompts,
   formatPromptMessages,
   formatError,
 } from "../output/formatter.ts";
-import { logger } from "../output/logger.ts";
 import { parseJsonArgs, readStdin } from "../lib/input.ts";
+import { withCommand } from "./with-command.ts";
 
 export function registerPromptCommand(program: Command) {
   program
     .command("prompt [server] [name] [args]")
     .description("list prompts for a server, or get a specific prompt")
     .action(
-      async (server: string | undefined, name: string | undefined, argsStr: string | undefined) => {
-        const { manager, formatOptions } = await getContext(program);
-        const spinner = logger.startSpinner(
-          server ? `Connecting to ${server}...` : "Connecting to servers...",
-          formatOptions,
-        );
-        try {
+      withCommand(
+        program,
+        { spinnerText: "Connecting to servers..." },
+        async (
+          { manager, formatOptions, spinner },
+          server?: string,
+          name?: string,
+          argsStr?: string,
+        ) => {
+          if (server) {
+            spinner.update(`Connecting to ${server}...`);
+          }
+
           if (server && name) {
             let args: Record<string, string> | undefined;
 
@@ -48,13 +53,7 @@ export function registerPromptCommand(program: Command) {
               console.error(formatError(`${err.server}: ${err.message}`, formatOptions));
             }
           }
-        } catch (err) {
-          spinner.error("Failed");
-          console.error(formatError(String(err), formatOptions));
-          process.exit(1);
-        } finally {
-          await manager.close();
-        }
-      },
+        },
+      ),
     );
 }

--- a/src/commands/resource.ts
+++ b/src/commands/resource.ts
@@ -1,46 +1,42 @@
 import type { Command } from "commander";
-import { getContext } from "../context.ts";
 import {
   formatResourceList,
   formatServerResources,
   formatResourceContents,
   formatError,
 } from "../output/formatter.ts";
-import { logger } from "../output/logger.ts";
+import { withCommand } from "./with-command.ts";
 
 export function registerResourceCommand(program: Command) {
   program
     .command("resource [server] [uri]")
     .description("list resources for a server, or read a specific resource")
-    .action(async (server: string | undefined, uri: string | undefined) => {
-      const { manager, formatOptions } = await getContext(program);
-      const spinner = logger.startSpinner(
-        server ? `Connecting to ${server}...` : "Connecting to servers...",
-        formatOptions,
-      );
-      try {
-        if (server && uri) {
-          const result = await manager.readResource(server, uri);
-          spinner.stop();
-          console.log(formatResourceContents(server, uri, result, formatOptions));
-        } else if (server) {
-          const resources = await manager.listResources(server);
-          spinner.stop();
-          console.log(formatServerResources(server, resources, formatOptions));
-        } else {
-          const { resources, errors } = await manager.getAllResources();
-          spinner.stop();
-          console.log(formatResourceList(resources, formatOptions));
-          for (const err of errors) {
-            console.error(formatError(`${err.server}: ${err.message}`, formatOptions));
+    .action(
+      withCommand(
+        program,
+        { spinnerText: "Connecting to servers..." },
+        async ({ manager, formatOptions, spinner }, server?: string, uri?: string) => {
+          if (server) {
+            spinner.update(`Connecting to ${server}...`);
           }
-        }
-      } catch (err) {
-        spinner.error("Failed");
-        console.error(formatError(String(err), formatOptions));
-        process.exit(1);
-      } finally {
-        await manager.close();
-      }
-    });
+
+          if (server && uri) {
+            const result = await manager.readResource(server, uri);
+            spinner.stop();
+            console.log(formatResourceContents(server, uri, result, formatOptions));
+          } else if (server) {
+            const resources = await manager.listResources(server);
+            spinner.stop();
+            console.log(formatServerResources(server, resources, formatOptions));
+          } else {
+            const { resources, errors } = await manager.getAllResources();
+            spinner.stop();
+            console.log(formatResourceList(resources, formatOptions));
+            for (const err of errors) {
+              console.error(formatError(`${err.server}: ${err.message}`, formatOptions));
+            }
+          }
+        },
+      ),
+    );
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -4,6 +4,7 @@ import { search } from "../search/index.ts";
 import { getStaleServers } from "../search/staleness.ts";
 import { formatError, formatSearchResults } from "../output/formatter.ts";
 import { logger } from "../output/logger.ts";
+import { DEFAULTS } from "../constants.ts";
 
 export function registerSearchCommand(program: Command) {
   program
@@ -11,7 +12,7 @@ export function registerSearchCommand(program: Command) {
     .description("search tools by keyword and/or semantic similarity")
     .option("-k, --keyword", "keyword/glob search only")
     .option("-q, --query", "semantic search only")
-    .option("-n, --limit <number>", "max results to return", "10")
+    .option("-n, --limit <number>", "max results to return", String(DEFAULTS.SEARCH_TOP_K))
     .action(
       async (terms: string[], options: { keyword?: boolean; query?: boolean; limit: string }) => {
         const query = terms.join(" ");

--- a/src/commands/servers.ts
+++ b/src/commands/servers.ts
@@ -1,16 +1,15 @@
 import { cyan, dim, green, yellow } from "ansis";
 import type { Command } from "commander";
-import { getContext } from "../context.ts";
 import { isStdioServer, isHttpServer } from "../config/schemas.ts";
-import { formatError, isInteractive } from "../output/formatter.ts";
+import { isInteractive } from "../output/formatter.ts";
+import { withCommand } from "./with-command.ts";
 
 export function registerServersCommand(program: Command) {
   program
     .command("servers")
     .description("List configured MCP servers")
-    .action(async () => {
-      const { manager, config, formatOptions } = await getContext(program);
-      try {
+    .action(
+      withCommand(program, {}, async ({ config, formatOptions }) => {
         const servers = Object.entries(config.servers.mcpServers);
 
         if (!isInteractive(formatOptions)) {
@@ -56,11 +55,6 @@ export function registerServersCommand(program: Command) {
             : dim(cfg.url);
           console.log(`${n}  ${type}  ${detail}`);
         }
-      } catch (err) {
-        console.error(formatError(String(err), formatOptions));
-        process.exit(1);
-      } finally {
-        await manager.close();
-      }
-    });
+      }),
+    );
 }

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -1,82 +1,66 @@
 import type { Command } from "commander";
-import { getContext } from "../context.ts";
 import {
   formatCallResult,
   formatError,
   formatTaskStatus,
   formatTasksList,
 } from "../output/formatter.ts";
-import { logger } from "../output/logger.ts";
+import { withCommand } from "./with-command.ts";
 
 export function registerTaskCommand(program: Command) {
   program
     .command("task <action> <server> [taskId]")
     .description("manage tasks (actions: get, list, result, cancel)")
-    .action(async (action: string, server: string, taskId: string | undefined) => {
-      const { manager, formatOptions } = await getContext(program);
-      const spinner = logger.startSpinner(`Connecting to ${server}...`, formatOptions);
+    .action(
+      withCommand(
+        program,
+        { spinnerText: "Connecting..." },
+        async (
+          { manager, formatOptions, spinner },
+          action: string,
+          server: string,
+          taskId?: string,
+        ) => {
+          spinner.update(`Connecting to ${server}...`);
 
-      try {
-        switch (action) {
-          case "list": {
-            const result = await manager.listTasks(server);
-            spinner.stop();
-            console.log(formatTasksList(result.tasks, result.nextCursor, formatOptions));
-            break;
-          }
-          case "get": {
-            if (!taskId) {
-              spinner.error("Missing task ID");
-              console.error(formatError("Usage: mcpx task get <server> <taskId>", formatOptions));
-              process.exit(1);
+          switch (action) {
+            case "list": {
+              const result = await manager.listTasks(server);
+              spinner.stop();
+              console.log(formatTasksList(result.tasks, result.nextCursor, formatOptions));
+              break;
             }
-            const task = await manager.getTask(server, taskId);
-            spinner.stop();
-            console.log(formatTaskStatus(task, formatOptions));
-            break;
-          }
-          case "result": {
-            if (!taskId) {
-              spinner.error("Missing task ID");
-              console.error(
-                formatError("Usage: mcpx task result <server> <taskId>", formatOptions),
-              );
-              process.exit(1);
+            case "get": {
+              if (!taskId) {
+                throw new Error("Usage: mcpx task get <server> <taskId>");
+              }
+              const task = await manager.getTask(server, taskId);
+              spinner.stop();
+              console.log(formatTaskStatus(task, formatOptions));
+              break;
             }
-            const result = await manager.getTaskResult(server, taskId);
-            spinner.stop();
-            console.log(formatCallResult(result, formatOptions));
-            break;
-          }
-          case "cancel": {
-            if (!taskId) {
-              spinner.error("Missing task ID");
-              console.error(
-                formatError("Usage: mcpx task cancel <server> <taskId>", formatOptions),
-              );
-              process.exit(1);
+            case "result": {
+              if (!taskId) {
+                throw new Error("Usage: mcpx task result <server> <taskId>");
+              }
+              const result = await manager.getTaskResult(server, taskId);
+              spinner.stop();
+              console.log(formatCallResult(result, formatOptions));
+              break;
             }
-            const cancelled = await manager.cancelTask(server, taskId);
-            spinner.stop();
-            console.log(formatTaskStatus(cancelled, formatOptions));
-            break;
+            case "cancel": {
+              if (!taskId) {
+                throw new Error("Usage: mcpx task cancel <server> <taskId>");
+              }
+              const cancelled = await manager.cancelTask(server, taskId);
+              spinner.stop();
+              console.log(formatTaskStatus(cancelled, formatOptions));
+              break;
+            }
+            default:
+              throw new Error(`Unknown task action: "${action}". Use: get, list, result, cancel`);
           }
-          default:
-            spinner.error("Unknown action");
-            console.error(
-              formatError(
-                `Unknown task action: "${action}". Use: get, list, result, cancel`,
-                formatOptions,
-              ),
-            );
-            process.exit(1);
-        }
-      } catch (err) {
-        spinner.error("Failed");
-        console.error(formatError(String(err), formatOptions));
-        process.exit(1);
-      } finally {
-        await manager.close();
-      }
-    });
+        },
+      ),
+    );
 }

--- a/src/commands/with-command.ts
+++ b/src/commands/with-command.ts
@@ -1,0 +1,59 @@
+import type { Command } from "commander";
+import { getContext, type AppContext } from "../context.ts";
+import { formatError } from "../output/formatter.ts";
+import { logger, type Spinner } from "../output/logger.ts";
+
+export interface CommandContext extends AppContext {
+  spinner: Spinner;
+}
+
+interface WithCommandOptions {
+  /** Spinner text shown during execution. If omitted, no spinner is started. */
+  spinnerText?: string;
+  /** Error message for spinner.error(). Defaults to "Failed". */
+  errorLabel?: string;
+}
+
+const noopSpinner: Spinner = {
+  update() {},
+  success() {},
+  error() {},
+  stop() {},
+};
+
+/**
+ * Wrap a command action with standard context setup, spinner, error handling,
+ * and manager cleanup.
+ *
+ * The handler receives { config, manager, formatOptions, spinner } and should:
+ *   1. Do async work
+ *   2. Call spinner.stop() when done
+ *   3. Output results via console.log()
+ *
+ * Errors are caught, formatted, and cause process.exit(1).
+ * manager.close() is always called in finally.
+ */
+export function withCommand<TArgs extends unknown[]>(
+  program: Command,
+  options: WithCommandOptions,
+  handler: (ctx: CommandContext, ...args: TArgs) => Promise<void>,
+): (...args: TArgs) => Promise<void> {
+  return async (...args: TArgs) => {
+    const appCtx = await getContext(program);
+    const { manager, formatOptions } = appCtx;
+
+    const spinner = options.spinnerText
+      ? logger.startSpinner(options.spinnerText, formatOptions)
+      : noopSpinner;
+
+    try {
+      await handler({ ...appCtx, spinner }, ...args);
+    } catch (err) {
+      spinner.error(options.errorLabel ?? "Failed");
+      console.error(formatError(String(err), formatOptions));
+      process.exit(1);
+    } finally {
+      await manager.close();
+    }
+  };
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,8 +1,10 @@
+import { ENV } from "../constants.ts";
+
 const ENV_VAR_PATTERN = /\$\{([^}]+)\}/g;
 
 /** Whether to throw on missing env vars (default: true) */
 function isStrictEnv(): boolean {
-  return process.env.MCP_STRICT_ENV !== "false";
+  return process.env[ENV.STRICT_ENV] !== "false";
 }
 
 /** Replace ${VAR_NAME} in a string with the corresponding env var value */
@@ -12,7 +14,7 @@ export function interpolateEnvString(value: string): string {
     if (envValue === undefined) {
       if (isStrictEnv()) {
         throw new Error(
-          `Environment variable "${varName}" is not set (set MCP_STRICT_ENV=false to warn instead)`,
+          `Environment variable "${varName}" is not set (set ${ENV.STRICT_ENV}=false to warn instead)`,
         );
       }
       console.warn(`Warning: environment variable "${varName}" is not set`);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "path";
 import { homedir } from "os";
 import { interpolateEnv } from "./env.ts";
+import { ENV } from "../constants.ts";
 import {
   type Config,
   type ServersFile,
@@ -36,7 +37,7 @@ function resolveConfigDir(configFlag?: string): string {
   if (configFlag) return resolve(configFlag);
 
   // 2. MCP_CONFIG_PATH env var
-  const envPath = process.env.MCP_CONFIG_PATH;
+  const envPath = process.env[ENV.CONFIG_PATH];
   if (envPath) return resolve(envPath);
 
   // 3. ./servers.json exists in cwd → use cwd
@@ -107,9 +108,14 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Confi
   return { configDir, servers, auth, searchIndex };
 }
 
+/** Write a JSON file to the config directory */
+async function saveJsonFile(configDir: string, filename: string, data: unknown): Promise<void> {
+  await Bun.write(join(configDir, filename), JSON.stringify(data, null, 2) + "\n");
+}
+
 /** Save auth.json to the config directory */
 export async function saveAuth(configDir: string, auth: AuthFile): Promise<void> {
-  await Bun.write(join(configDir, "auth.json"), JSON.stringify(auth, null, 2) + "\n");
+  return saveJsonFile(configDir, "auth.json", auth);
 }
 
 /** Load search.json from the config directory */
@@ -120,12 +126,12 @@ export async function loadSearchIndex(configDir: string): Promise<SearchIndex> {
 
 /** Save search.json to the config directory */
 export async function saveSearchIndex(configDir: string, index: SearchIndex): Promise<void> {
-  await Bun.write(join(configDir, "search.json"), JSON.stringify(index, null, 2) + "\n");
+  return saveJsonFile(configDir, "search.json", index);
 }
 
 /** Save servers.json to the config directory */
 export async function saveServers(configDir: string, servers: ServersFile): Promise<void> {
-  await Bun.write(join(configDir, "servers.json"), JSON.stringify(servers, null, 2) + "\n");
+  return saveJsonFile(configDir, "servers.json", servers);
 }
 
 /** Load servers.json without env interpolation (preserves ${VAR} placeholders) */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,19 @@
+/** Environment variable names used by mcpx */
+export const ENV = {
+  DEBUG: "MCP_DEBUG",
+  CONCURRENCY: "MCP_CONCURRENCY",
+  TIMEOUT: "MCP_TIMEOUT",
+  MAX_RETRIES: "MCP_MAX_RETRIES",
+  STRICT_ENV: "MCP_STRICT_ENV",
+  CONFIG_PATH: "MCP_CONFIG_PATH",
+} as const;
+
+/** Default values for configurable options */
+export const DEFAULTS = {
+  CONCURRENCY: 5,
+  TIMEOUT_SECONDS: 1800,
+  MAX_RETRIES: 3,
+  TASK_TTL_MS: 60_000,
+  SEARCH_TOP_K: 10,
+  LOG_LEVEL: "warning",
+} as const;

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,6 +4,7 @@ import { ServerManager } from "./client/manager.ts";
 import type { Config } from "./config/schemas.ts";
 import type { FormatOptions } from "./output/formatter.ts";
 import { logger } from "./output/logger.ts";
+import { ENV, DEFAULTS } from "./constants.ts";
 
 export interface AppContext {
   config: Config;
@@ -21,14 +22,14 @@ export async function getContext(program: Command): Promise<AppContext> {
 
   const verbose = !!(
     (opts.verbose as boolean | undefined) ||
-    process.env.MCP_DEBUG === "1" ||
-    process.env.MCP_DEBUG === "true"
+    process.env[ENV.DEBUG] === "1" ||
+    process.env[ENV.DEBUG] === "true"
   );
   const showSecrets = !!(opts.showSecrets as boolean | undefined);
-  const concurrency = Number(process.env.MCP_CONCURRENCY ?? 5);
-  const timeout = Number(process.env.MCP_TIMEOUT ?? 1800) * 1000;
-  const maxRetries = Number(process.env.MCP_MAX_RETRIES ?? 3);
-  const logLevel = (opts.logLevel as string | undefined) ?? "warning";
+  const concurrency = Number(process.env[ENV.CONCURRENCY] ?? DEFAULTS.CONCURRENCY);
+  const timeout = Number(process.env[ENV.TIMEOUT] ?? DEFAULTS.TIMEOUT_SECONDS) * 1000;
+  const maxRetries = Number(process.env[ENV.MAX_RETRIES] ?? DEFAULTS.MAX_RETRIES);
+  const logLevel = (opts.logLevel as string | undefined) ?? DEFAULTS.LOG_LEVEL;
 
   const json = !!(opts.json as boolean | undefined);
   // Commander's --no-interactive sets opts.interactive = false (default true)

--- a/src/output/format-output.ts
+++ b/src/output/format-output.ts
@@ -1,0 +1,18 @@
+import type { FormatOptions } from "./formatter.ts";
+import { isInteractive } from "./formatter.ts";
+
+/**
+ * Format output with automatic JSON/interactive branching.
+ * In non-interactive mode, returns JSON.stringify of jsonData.
+ * In interactive mode, calls interactiveFn() for formatted output.
+ */
+export function formatOutput(
+  jsonData: unknown,
+  interactiveFn: () => string,
+  options: FormatOptions,
+): string {
+  if (!isInteractive(options)) {
+    return JSON.stringify(jsonData, null, 2);
+  }
+  return interactiveFn();
+}

--- a/src/output/format-table.ts
+++ b/src/output/format-table.ts
@@ -1,0 +1,61 @@
+import ansis from "ansis";
+import { dim } from "ansis";
+import { wrapDescription } from "./formatter.ts";
+
+export interface Column<T> {
+  value: (item: T) => string;
+  style: (text: string) => string;
+}
+
+export interface TableOptions<T> {
+  columns: Column<T>[];
+  description?: (item: T) => string | undefined;
+  separator?: string;
+  emptyMessage?: string;
+}
+
+/** Measure visible length of a string (excluding ANSI escape codes) */
+function visibleLength(s: string): number {
+  return ansis.strip(s).length;
+}
+
+/** Get terminal width, or undefined if not a TTY */
+function getTerminalWidth(): number | undefined {
+  if (process.stdout.isTTY) return Math.max(process.stdout.columns - 1, 40);
+  return undefined;
+}
+
+/**
+ * Format a list of items as an aligned table with optional description wrapping.
+ */
+export function formatTable<T>(items: T[], options: TableOptions<T>): string {
+  if (items.length === 0) {
+    return dim(options.emptyMessage ?? "No items found");
+  }
+
+  const sep = options.separator ?? "  ";
+  const termWidth = getTerminalWidth();
+
+  // Calculate max width for each column
+  const maxWidths = options.columns.map((col) =>
+    Math.max(...items.map((item) => col.value(item).length)),
+  );
+
+  return items
+    .map((item) => {
+      const parts = options.columns.map((col, i) =>
+        col.style(col.value(item).padEnd(maxWidths[i]!)),
+      );
+      const prefix = parts.join(sep);
+
+      const desc = options.description?.(item);
+      if (desc) {
+        const pw = visibleLength(prefix) + sep.length;
+        const formatted = termWidth != null ? wrapDescription(desc, pw, termWidth) : dim(desc);
+        return `${prefix}${sep}${formatted}`;
+      }
+
+      return prefix;
+    })
+    .join("\n");
+}

--- a/src/output/format-table.ts
+++ b/src/output/format-table.ts
@@ -43,9 +43,11 @@ export function formatTable<T>(items: T[], options: TableOptions<T>): string {
 
   return items
     .map((item) => {
-      const parts = options.columns.map((col, i) =>
-        col.style(col.value(item).padEnd(maxWidths[i]!)),
-      );
+      const parts = options.columns.map((col, i) => {
+        const raw = col.value(item);
+        const pad = maxWidths[i]! - raw.length;
+        return col.style(raw) + " ".repeat(Math.max(0, pad));
+      });
       const prefix = parts.join(sep);
 
       const desc = options.description?.(item);

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -3,6 +3,8 @@ import type { Tool, Resource, Prompt } from "../config/schemas.ts";
 import type { ToolWithServer, ResourceWithServer, PromptWithServer } from "../client/manager.ts";
 import type { ValidationError } from "../validation/schema.ts";
 import type { SearchResult } from "../search/index.ts";
+import { formatOutput } from "./format-output.ts";
+import { formatTable } from "./format-table.ts";
 
 export interface FormatOptions {
   json?: boolean;
@@ -109,133 +111,104 @@ const KNOWN_CAPABILITIES = ["tools", "resources", "prompts", "logging", "complet
 
 /** Format a full server overview (version, capabilities, tools, counts) */
 export function formatServerOverview(overview: ServerOverview, options: FormatOptions): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      {
-        server: overview.serverName,
-        version: overview.version ?? null,
-        capabilities: overview.capabilities ?? null,
-        instructions: overview.instructions ?? null,
-        tools: overview.tools.map((t) => ({ name: t.name, description: t.description ?? "" })),
-        resourceCount: overview.resourceCount,
-        promptCount: overview.promptCount,
-      },
-      null,
-      2,
-    );
-  }
+  return formatOutput(
+    {
+      server: overview.serverName,
+      version: overview.version ?? null,
+      capabilities: overview.capabilities ?? null,
+      instructions: overview.instructions ?? null,
+      tools: overview.tools.map((t) => ({ name: t.name, description: t.description ?? "" })),
+      resourceCount: overview.resourceCount,
+      promptCount: overview.promptCount,
+    },
+    () => {
+      const lines: string[] = [];
 
-  const lines: string[] = [];
-
-  // Header: server name + version
-  const header = cyan.bold(overview.serverName);
-  if (overview.version) {
-    lines.push(
-      `${header}  ${dim(`v${overview.version.version}`)}  ${dim(`(${overview.version.name})`)}`,
-    );
-  } else {
-    lines.push(header);
-  }
-
-  // Capabilities
-  if (overview.capabilities) {
-    lines.push("");
-    lines.push(bold("Capabilities:"));
-    const caps = overview.capabilities;
-    const present = KNOWN_CAPABILITIES.filter((k) => k in caps);
-    const absent = KNOWN_CAPABILITIES.filter((k) => !(k in caps));
-    const capLines: string[] = [];
-    for (const k of present) capLines.push(`  ${green("✓")} ${k}`);
-    for (const k of absent) capLines.push(`  ${dim("✗")} ${dim(k)}`);
-    lines.push(...capLines);
-  }
-
-  // Instructions
-  if (overview.instructions) {
-    lines.push("");
-    lines.push(bold("Instructions:"));
-    lines.push(`  ${dim(overview.instructions)}`);
-  }
-
-  // Tools
-  lines.push("");
-  if (overview.tools.length === 0) {
-    lines.push(bold("Tools:") + " " + dim("none"));
-  } else {
-    lines.push(bold(`Tools (${overview.tools.length}):`));
-    const maxName = Math.max(...overview.tools.map((t) => t.name.length));
-    const termWidth = getTerminalWidth();
-    for (let i = 0; i < overview.tools.length; i++) {
-      const t = overview.tools[i];
-      if (i > 0) lines.push("");
-      const name = `  ${bold(t.name.padEnd(maxName))}`;
-      if (t.description) {
-        const pw = visibleLength(name) + 2;
-        const desc =
-          termWidth != null ? wrapDescription(t.description, pw, termWidth) : dim(t.description);
-        lines.push(`${name}  ${desc}`);
+      // Header: server name + version
+      const header = cyan.bold(overview.serverName);
+      if (overview.version) {
+        lines.push(
+          `${header}  ${dim(`v${overview.version.version}`)}  ${dim(`(${overview.version.name})`)}`,
+        );
       } else {
-        lines.push(name);
+        lines.push(header);
       }
-    }
-  }
 
-  // Resource/prompt counts
-  const counts: string[] = [];
-  counts.push(`Resources: ${overview.resourceCount}`);
-  counts.push(`Prompts: ${overview.promptCount}`);
-  lines.push("");
-  lines.push(dim(counts.join(" | ")));
+      // Capabilities
+      if (overview.capabilities) {
+        lines.push("");
+        lines.push(bold("Capabilities:"));
+        const caps = overview.capabilities;
+        const present = KNOWN_CAPABILITIES.filter((k) => k in caps);
+        const absent = KNOWN_CAPABILITIES.filter((k) => !(k in caps));
+        for (const k of present) lines.push(`  ${green("✓")} ${k}`);
+        for (const k of absent) lines.push(`  ${dim("✗")} ${dim(k)}`);
+      }
 
-  return lines.join("\n");
+      // Instructions
+      if (overview.instructions) {
+        lines.push("");
+        lines.push(bold("Instructions:"));
+        lines.push(`  ${dim(overview.instructions)}`);
+      }
+
+      // Tools
+      lines.push("");
+      if (overview.tools.length === 0) {
+        lines.push(bold("Tools:") + " " + dim("none"));
+      } else {
+        lines.push(bold(`Tools (${overview.tools.length}):`));
+        const maxName = Math.max(...overview.tools.map((t) => t.name.length));
+        const termWidth = getTerminalWidth();
+        for (let i = 0; i < overview.tools.length; i++) {
+          const t = overview.tools[i];
+          if (i > 0) lines.push("");
+          const name = `  ${bold(t.name.padEnd(maxName))}`;
+          if (t.description) {
+            const pw = visibleLength(name) + 2;
+            const desc =
+              termWidth != null
+                ? wrapDescription(t.description, pw, termWidth)
+                : dim(t.description);
+            lines.push(`${name}  ${desc}`);
+          } else {
+            lines.push(name);
+          }
+        }
+      }
+
+      // Resource/prompt counts
+      const counts: string[] = [];
+      counts.push(`Resources: ${overview.resourceCount}`);
+      counts.push(`Prompts: ${overview.promptCount}`);
+      lines.push("");
+      lines.push(dim(counts.join(" | ")));
+
+      return lines.join("\n");
+    },
+    options,
+  );
 }
 
 /** Format a list of tools with server names */
 export function formatToolList(tools: ToolWithServer[], options: FormatOptions): string {
-  if (!isInteractive(options)) {
-    if (options.withDescriptions) {
-      return JSON.stringify(
-        tools.map((t) => ({
-          server: t.server,
-          tool: t.tool.name,
-          description: t.tool.description ?? "",
-        })),
-        null,
-        2,
-      );
-    }
-    return JSON.stringify(
-      tools.map((t) => ({ server: t.server, tool: t.tool.name })),
-      null,
-      2,
-    );
-  }
-
-  if (tools.length === 0) {
-    return dim("No tools found");
-  }
-
-  // Calculate column widths
-  const maxServer = Math.max(...tools.map((t) => t.server.length));
-  const maxTool = Math.max(...tools.map((t) => t.tool.name.length));
-  const termWidth = getTerminalWidth();
-
-  return tools
-    .map((t) => {
-      const server = cyan(t.server.padEnd(maxServer));
-      const tool = bold(t.tool.name.padEnd(maxTool));
-      if (options.withDescriptions && t.tool.description) {
-        const prefix = `${server}  ${tool}`;
-        const pw = visibleLength(prefix) + 2;
-        const desc =
-          termWidth != null
-            ? wrapDescription(t.tool.description, pw, termWidth)
-            : dim(t.tool.description);
-        return `${prefix}  ${desc}`;
-      }
-      return `${server}  ${tool}`;
-    })
-    .join("\n");
+  return formatOutput(
+    tools.map((t) => ({
+      server: t.server,
+      tool: t.tool.name,
+      ...(options.withDescriptions ? { description: t.tool.description ?? "" } : {}),
+    })),
+    () =>
+      formatTable(tools, {
+        columns: [
+          { value: (t) => t.server, style: cyan },
+          { value: (t) => t.tool.name, style: bold },
+        ],
+        description: options.withDescriptions ? (t) => t.tool.description : undefined,
+        emptyMessage: "No tools found",
+      }),
+    options,
+  );
 }
 
 /** Format tools for a single server */
@@ -244,66 +217,46 @@ export function formatServerTools(
   tools: Tool[],
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      {
-        server: serverName,
-        tools: tools.map((t) => ({ name: t.name, description: t.description ?? "" })),
-      },
-      null,
-      2,
-    );
-  }
-
-  if (tools.length === 0) {
-    return dim(`No tools found for ${serverName}`);
-  }
-
-  const header = cyan.bold(serverName);
-  const maxName = Math.max(...tools.map((t) => t.name.length));
-  const termWidth = getTerminalWidth();
-
-  const lines = tools.map((t) => {
-    const name = `  ${bold(t.name.padEnd(maxName))}`;
-    if (t.description) {
-      const pw = visibleLength(name) + 2;
-      const desc =
-        termWidth != null ? wrapDescription(t.description, pw, termWidth) : dim(t.description);
-      return `${name}  ${desc}`;
-    }
-    return name;
-  });
-
-  return [header, ...lines].join("\n");
+  return formatOutput(
+    {
+      server: serverName,
+      tools: tools.map((t) => ({ name: t.name, description: t.description ?? "" })),
+    },
+    () => {
+      if (tools.length === 0) {
+        return dim(`No tools found for ${serverName}`);
+      }
+      const header = cyan.bold(serverName);
+      const body = formatTable(tools, {
+        columns: [{ value: (t) => `  ${t.name}`, style: bold }],
+        description: (t) => t.description,
+      });
+      return `${header}\n${body}`;
+    },
+    options,
+  );
 }
 
 /** Format a tool schema */
 export function formatToolSchema(serverName: string, tool: Tool, options: FormatOptions): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      {
-        server: serverName,
-        tool: tool.name,
-        description: tool.description ?? "",
-        inputSchema: tool.inputSchema,
-      },
-      null,
-      2,
-    );
-  }
-
-  const lines: string[] = [];
-  lines.push(`${cyan(serverName)}/${bold(tool.name)}`);
-
-  if (tool.description) {
-    lines.push(dim(tool.description));
-  }
-
-  lines.push("");
-  lines.push(bold("Input Schema:"));
-  lines.push(formatSchema(tool.inputSchema, 2));
-
-  return lines.join("\n");
+  return formatOutput(
+    {
+      server: serverName,
+      tool: tool.name,
+      description: tool.description ?? "",
+      inputSchema: tool.inputSchema,
+    },
+    () => {
+      const lines: string[] = [];
+      lines.push(`${cyan(serverName)}/${bold(tool.name)}`);
+      if (tool.description) lines.push(dim(tool.description));
+      lines.push("");
+      lines.push(bold("Input Schema:"));
+      lines.push(formatSchema(tool.inputSchema, 2));
+      return lines.join("\n");
+    },
+    options,
+  );
 }
 
 /** Format a JSON schema as a readable parameter list */
@@ -329,37 +282,29 @@ function formatSchema(schema: Tool["inputSchema"], indent: number): string {
 
 /** Format detailed tool help with example payload */
 export function formatToolHelp(serverName: string, tool: Tool, options: FormatOptions): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      {
-        server: serverName,
-        tool: tool.name,
-        description: tool.description ?? "",
-        inputSchema: tool.inputSchema,
-        example: generateExample(tool.inputSchema),
-      },
-      null,
-      2,
-    );
-  }
-
-  const lines: string[] = [];
-  lines.push(`${cyan(serverName)}/${bold(tool.name)}`);
-
-  if (tool.description) {
-    lines.push(dim(tool.description));
-  }
-
-  lines.push("");
-  lines.push(bold("Parameters:"));
-  lines.push(formatSchema(tool.inputSchema, 2));
-
-  const example = generateExample(tool.inputSchema);
-  lines.push("");
-  lines.push(bold("Example:"));
-  lines.push(dim(`  mcpx call ${serverName} ${tool.name} '${JSON.stringify(example)}'`));
-
-  return lines.join("\n");
+  return formatOutput(
+    {
+      server: serverName,
+      tool: tool.name,
+      description: tool.description ?? "",
+      inputSchema: tool.inputSchema,
+      example: generateExample(tool.inputSchema),
+    },
+    () => {
+      const lines: string[] = [];
+      lines.push(`${cyan(serverName)}/${bold(tool.name)}`);
+      if (tool.description) lines.push(dim(tool.description));
+      lines.push("");
+      lines.push(bold("Parameters:"));
+      lines.push(formatSchema(tool.inputSchema, 2));
+      const example = generateExample(tool.inputSchema);
+      lines.push("");
+      lines.push(bold("Example:"));
+      lines.push(dim(`  mcpx call ${serverName} ${tool.name} '${JSON.stringify(example)}'`));
+      return lines.join("\n");
+    },
+    options,
+  );
 }
 
 /** Generate an example payload from a JSON schema */
@@ -370,7 +315,6 @@ function generateExample(schema: Tool["inputSchema"]): Record<string, unknown> {
 
   for (const [name, prop] of Object.entries(properties)) {
     const p = prop as Record<string, unknown>;
-    // Include required fields and first few optional fields
     if (required.has(name) || Object.keys(example).length < 3) {
       example[name] = exampleValue(name, p);
     }
@@ -380,15 +324,8 @@ function generateExample(schema: Tool["inputSchema"]): Record<string, unknown> {
 }
 
 function exampleValue(name: string, prop: Record<string, unknown>): unknown {
-  // Use enum first choice if available
-  if (Array.isArray(prop.enum) && prop.enum.length > 0) {
-    return prop.enum[0];
-  }
-
-  // Use default if provided
-  if (prop.default !== undefined) {
-    return prop.default;
-  }
+  if (Array.isArray(prop.enum) && prop.enum.length > 0) return prop.enum[0];
+  if (prop.default !== undefined) return prop.default;
 
   const type = prop.type as string | undefined;
   switch (type) {
@@ -438,51 +375,46 @@ export function formatValidationErrors(
   errors: ValidationError[],
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify({
-      error: "validation",
-      server: serverName,
-      tool: toolName,
-      details: errors,
-    });
-  }
-
-  const header = `${red("error:")} invalid arguments for ${cyan(serverName)}/${bold(toolName)}`;
-  const details = errors.map((e) => `  ${yellow(e.path)}: ${e.message}`).join("\n");
-  return `${header}\n${details}`;
+  return formatOutput(
+    { error: "validation", server: serverName, tool: toolName, details: errors },
+    () => {
+      const header = `${red("error:")} invalid arguments for ${cyan(serverName)}/${bold(toolName)}`;
+      const details = errors.map((e) => `  ${yellow(e.path)}: ${e.message}`).join("\n");
+      return `${header}\n${details}`;
+    },
+    options,
+  );
 }
 
 /** Format search results */
 export function formatSearchResults(results: SearchResult[], options: FormatOptions): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(results, null, 2);
-  }
+  return formatOutput(
+    results,
+    () => {
+      if (results.length === 0) {
+        return dim("No matching tools found");
+      }
 
-  if (results.length === 0) {
-    return dim("No matching tools found");
-  }
+      const termWidth = getTerminalWidth();
+      const descIndent = 2;
 
-  const termWidth = getTerminalWidth();
-  const descIndent = 2;
-
-  return results
-    .map((r) => {
-      const header = `${cyan(r.server)}  ${bold(r.tool)}  ${yellow(r.score.toFixed(2))}`;
-
-      // Join all description lines into a single string for wrapping
-      const fullDesc = r.description
-        .split("\n")
-        .map((l) => l.trim())
-        .filter((l) => l.length > 0)
-        .join(" ");
-
-      const indent = " ".repeat(descIndent);
-      const desc =
-        termWidth != null ? wrapDescription(fullDesc, descIndent, termWidth) : dim(fullDesc);
-
-      return `${header}\n${indent}${desc}`;
-    })
-    .join("\n\n");
+      return results
+        .map((r) => {
+          const header = `${cyan(r.server)}  ${bold(r.tool)}  ${yellow(r.score.toFixed(2))}`;
+          const fullDesc = r.description
+            .split("\n")
+            .map((l) => l.trim())
+            .filter((l) => l.length > 0)
+            .join(" ");
+          const indent = " ".repeat(descIndent);
+          const desc =
+            termWidth != null ? wrapDescription(fullDesc, descIndent, termWidth) : dim(fullDesc);
+          return `${header}\n${indent}${desc}`;
+        })
+        .join("\n\n");
+    },
+    options,
+  );
 }
 
 /** Format a list of resources with server names */
@@ -490,43 +422,24 @@ export function formatResourceList(
   resources: ResourceWithServer[],
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      resources.map((r) => ({
-        server: r.server,
-        uri: r.resource.uri,
-        name: r.resource.name,
-        ...(options.withDescriptions ? { description: r.resource.description ?? "" } : {}),
-      })),
-      null,
-      2,
-    );
-  }
-
-  if (resources.length === 0) {
-    return dim("No resources found");
-  }
-
-  const maxServer = Math.max(...resources.map((r) => r.server.length));
-  const maxUri = Math.max(...resources.map((r) => r.resource.uri.length));
-  const termWidth = getTerminalWidth();
-
-  return resources
-    .map((r) => {
-      const server = cyan(r.server.padEnd(maxServer));
-      const uri = bold(r.resource.uri.padEnd(maxUri));
-      if (options.withDescriptions && r.resource.description) {
-        const prefix = `${server}  ${uri}`;
-        const pw = visibleLength(prefix) + 2;
-        const desc =
-          termWidth != null
-            ? wrapDescription(r.resource.description, pw, termWidth)
-            : dim(r.resource.description);
-        return `${prefix}  ${desc}`;
-      }
-      return `${server}  ${uri}`;
-    })
-    .join("\n");
+  return formatOutput(
+    resources.map((r) => ({
+      server: r.server,
+      uri: r.resource.uri,
+      name: r.resource.name,
+      ...(options.withDescriptions ? { description: r.resource.description ?? "" } : {}),
+    })),
+    () =>
+      formatTable(resources, {
+        columns: [
+          { value: (r) => r.server, style: cyan },
+          { value: (r) => r.resource.uri, style: bold },
+        ],
+        description: options.withDescriptions ? (r) => r.resource.description : undefined,
+        emptyMessage: "No resources found",
+      }),
+    options,
+  );
 }
 
 /** Format resources for a single server */
@@ -535,42 +448,29 @@ export function formatServerResources(
   resources: Resource[],
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      {
-        server: serverName,
-        resources: resources.map((r) => ({
-          uri: r.uri,
-          name: r.name,
-          description: r.description ?? "",
-          mimeType: r.mimeType ?? "",
-        })),
-      },
-      null,
-      2,
-    );
-  }
-
-  if (resources.length === 0) {
-    return dim(`No resources found for ${serverName}`);
-  }
-
-  const header = cyan.bold(serverName);
-  const maxUri = Math.max(...resources.map((r) => r.uri.length));
-  const termWidth = getTerminalWidth();
-
-  const lines = resources.map((r) => {
-    const uri = `  ${bold(r.uri.padEnd(maxUri))}`;
-    if (r.description) {
-      const pw = visibleLength(uri) + 2;
-      const desc =
-        termWidth != null ? wrapDescription(r.description, pw, termWidth) : dim(r.description);
-      return `${uri}  ${desc}`;
-    }
-    return uri;
-  });
-
-  return [header, ...lines].join("\n");
+  return formatOutput(
+    {
+      server: serverName,
+      resources: resources.map((r) => ({
+        uri: r.uri,
+        name: r.name,
+        description: r.description ?? "",
+        mimeType: r.mimeType ?? "",
+      })),
+    },
+    () => {
+      if (resources.length === 0) {
+        return dim(`No resources found for ${serverName}`);
+      }
+      const header = cyan.bold(serverName);
+      const body = formatTable(resources, {
+        columns: [{ value: (r) => `  ${r.uri}`, style: bold }],
+        description: (r) => r.description,
+      });
+      return `${header}\n${body}`;
+    },
+    options,
+  );
 }
 
 /** Format resource contents */
@@ -580,74 +480,53 @@ export function formatResourceContents(
   result: unknown,
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      { server: serverName, uri, contents: (result as { contents: unknown })?.contents ?? result },
-      null,
-      2,
-    );
-  }
+  return formatOutput(
+    { server: serverName, uri, contents: (result as { contents: unknown })?.contents ?? result },
+    () => {
+      const contents =
+        (result as { contents?: Array<{ text?: string; blob?: string; mimeType?: string }> })
+          ?.contents ?? [];
+      const lines: string[] = [];
+      lines.push(`${cyan(serverName)}/${bold(uri)}`);
+      lines.push("");
 
-  const contents =
-    (result as { contents?: Array<{ text?: string; blob?: string; mimeType?: string }> })
-      ?.contents ?? [];
-  const lines: string[] = [];
-  lines.push(`${cyan(serverName)}/${bold(uri)}`);
-  lines.push("");
-
-  if (contents.length === 0) {
-    lines.push(dim("(empty)"));
-  } else {
-    for (const item of contents) {
-      if (item.text !== undefined) {
-        lines.push(item.text);
-      } else if (item.blob !== undefined) {
-        lines.push(dim(`<binary blob, ${item.blob.length} bytes base64>`));
+      if (contents.length === 0) {
+        lines.push(dim("(empty)"));
+      } else {
+        for (const item of contents) {
+          if (item.text !== undefined) {
+            lines.push(item.text);
+          } else if (item.blob !== undefined) {
+            lines.push(dim(`<binary blob, ${item.blob.length} bytes base64>`));
+          }
+        }
       }
-    }
-  }
 
-  return lines.join("\n");
+      return lines.join("\n");
+    },
+    options,
+  );
 }
 
 /** Format a list of prompts with server names */
 export function formatPromptList(prompts: PromptWithServer[], options: FormatOptions): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      prompts.map((p) => ({
-        server: p.server,
-        name: p.prompt.name,
-        ...(options.withDescriptions ? { description: p.prompt.description ?? "" } : {}),
-      })),
-      null,
-      2,
-    );
-  }
-
-  if (prompts.length === 0) {
-    return dim("No prompts found");
-  }
-
-  const maxServer = Math.max(...prompts.map((p) => p.server.length));
-  const maxName = Math.max(...prompts.map((p) => p.prompt.name.length));
-  const termWidth = getTerminalWidth();
-
-  return prompts
-    .map((p) => {
-      const server = cyan(p.server.padEnd(maxServer));
-      const name = bold(p.prompt.name.padEnd(maxName));
-      if (options.withDescriptions && p.prompt.description) {
-        const prefix = `${server}  ${name}`;
-        const pw = visibleLength(prefix) + 2;
-        const desc =
-          termWidth != null
-            ? wrapDescription(p.prompt.description, pw, termWidth)
-            : dim(p.prompt.description);
-        return `${prefix}  ${desc}`;
-      }
-      return `${server}  ${name}`;
-    })
-    .join("\n");
+  return formatOutput(
+    prompts.map((p) => ({
+      server: p.server,
+      name: p.prompt.name,
+      ...(options.withDescriptions ? { description: p.prompt.description ?? "" } : {}),
+    })),
+    () =>
+      formatTable(prompts, {
+        columns: [
+          { value: (p) => p.server, style: cyan },
+          { value: (p) => p.prompt.name, style: bold },
+        ],
+        description: options.withDescriptions ? (p) => p.prompt.description : undefined,
+        emptyMessage: "No prompts found",
+      }),
+    options,
+  );
 }
 
 /** Format prompts for a single server */
@@ -656,47 +535,44 @@ export function formatServerPrompts(
   prompts: Prompt[],
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      {
-        server: serverName,
-        prompts: prompts.map((p) => ({
-          name: p.name,
-          description: p.description ?? "",
-          arguments: p.arguments ?? [],
-        })),
-      },
-      null,
-      2,
-    );
-  }
+  return formatOutput(
+    {
+      server: serverName,
+      prompts: prompts.map((p) => ({
+        name: p.name,
+        description: p.description ?? "",
+        arguments: p.arguments ?? [],
+      })),
+    },
+    () => {
+      if (prompts.length === 0) {
+        return dim(`No prompts found for ${serverName}`);
+      }
 
-  if (prompts.length === 0) {
-    return dim(`No prompts found for ${serverName}`);
-  }
+      const header = cyan.bold(serverName);
+      const maxName = Math.max(...prompts.map((p) => p.name.length));
+      const termWidth = getTerminalWidth();
 
-  const header = cyan.bold(serverName);
-  const maxName = Math.max(...prompts.map((p) => p.name.length));
+      const lines = prompts.map((p) => {
+        const name = `  ${bold(p.name.padEnd(maxName))}`;
+        const args =
+          p.arguments && p.arguments.length > 0
+            ? `  ${dim(`(${p.arguments.map((a) => (a.required ? a.name : `[${a.name}]`)).join(", ")})`)}`
+            : "";
+        if (p.description) {
+          const prefix = `${name}${args}`;
+          const pw = visibleLength(prefix) + 2;
+          const desc =
+            termWidth != null ? wrapDescription(p.description, pw, termWidth) : dim(p.description);
+          return `${prefix}  ${desc}`;
+        }
+        return `${name}${args}`;
+      });
 
-  const termWidth = getTerminalWidth();
-
-  const lines = prompts.map((p) => {
-    const name = `  ${bold(p.name.padEnd(maxName))}`;
-    const args =
-      p.arguments && p.arguments.length > 0
-        ? `  ${dim(`(${p.arguments.map((a) => (a.required ? a.name : `[${a.name}]`)).join(", ")})`)}`
-        : "";
-    if (p.description) {
-      const prefix = `${name}${args}`;
-      const pw = visibleLength(prefix) + 2;
-      const desc =
-        termWidth != null ? wrapDescription(p.description, pw, termWidth) : dim(p.description);
-      return `${prefix}  ${desc}`;
-    }
-    return `${name}${args}`;
-  });
-
-  return [header, ...lines].join("\n");
+      return [header, ...lines].join("\n");
+    },
+    options,
+  );
 }
 
 /** Format prompt messages */
@@ -706,80 +582,58 @@ export function formatPromptMessages(
   result: unknown,
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify({ server: serverName, prompt: name, ...(result as object) }, null, 2);
-  }
-
-  const r = result as {
-    description?: string;
-    messages?: Array<{ role: string; content: { type: string; text?: string } }>;
-  };
-  const lines: string[] = [];
-  lines.push(`${cyan(serverName)}/${bold(name)}`);
-
-  if (r.description) {
-    lines.push(dim(r.description));
-  }
-
-  lines.push("");
-
-  for (const msg of r.messages ?? []) {
-    lines.push(`${bold(msg.role)}:`);
-    if (msg.content.text !== undefined) {
-      lines.push(`  ${msg.content.text}`);
-    }
-  }
-
-  return lines.join("\n");
+  return formatOutput(
+    { server: serverName, prompt: name, ...(result as object) },
+    () => {
+      const r = result as {
+        description?: string;
+        messages?: Array<{ role: string; content: { type: string; text?: string } }>;
+      };
+      const lines: string[] = [];
+      lines.push(`${cyan(serverName)}/${bold(name)}`);
+      if (r.description) lines.push(dim(r.description));
+      lines.push("");
+      for (const msg of r.messages ?? []) {
+        lines.push(`${bold(msg.role)}:`);
+        if (msg.content.text !== undefined) {
+          lines.push(`  ${msg.content.text}`);
+        }
+      }
+      return lines.join("\n");
+    },
+    options,
+  );
 }
 
 /** Format a unified list of tools, resources, and prompts across servers */
 export function formatUnifiedList(items: UnifiedItem[], options: FormatOptions): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(
-      items.map((i) => ({
-        server: i.server,
-        type: i.type,
-        name: i.name,
-        ...(options.withDescriptions ? { description: i.description ?? "" } : {}),
-      })),
-      null,
-      2,
-    );
-  }
-
-  if (items.length === 0) {
-    return dim("No tools, resources, or prompts found");
-  }
-
-  const maxServer = Math.max(...items.map((i) => i.server.length));
-  const maxType = 8; // "resource" is the longest at 8 chars
-  const maxName = Math.max(...items.map((i) => i.name.length));
-
   const typeLabel = (t: UnifiedItem["type"]) => {
+    const maxType = 8; // "resource" is the longest at 8 chars
     const padded = t.padEnd(maxType);
     if (t === "tool") return green(padded);
     if (t === "resource") return cyan(padded);
     return yellow(padded);
   };
 
-  const termWidth = getTerminalWidth();
-
-  return items
-    .map((i) => {
-      const server = cyan(i.server.padEnd(maxServer));
-      const type = typeLabel(i.type);
-      const name = bold(i.name.padEnd(maxName));
-      if (options.withDescriptions && i.description) {
-        const prefix = `${server}  ${type}  ${name}`;
-        const pw = visibleLength(prefix) + 2;
-        const desc =
-          termWidth != null ? wrapDescription(i.description, pw, termWidth) : dim(i.description);
-        return `${prefix}  ${desc}`;
-      }
-      return `${server}  ${type}  ${name}`;
-    })
-    .join("\n");
+  return formatOutput(
+    items.map((i) => ({
+      server: i.server,
+      type: i.type,
+      name: i.name,
+      ...(options.withDescriptions ? { description: i.description ?? "" } : {}),
+    })),
+    () =>
+      formatTable(items, {
+        columns: [
+          { value: (i) => i.server, style: cyan },
+          { value: (i) => i.type, style: typeLabel },
+          { value: (i) => i.name, style: bold },
+        ],
+        description: options.withDescriptions ? (i) => i.description : undefined,
+        emptyMessage: "No tools, resources, or prompts found",
+      }),
+    options,
+  );
 }
 
 /** Format a single task status */
@@ -787,36 +641,38 @@ export function formatTaskStatus(
   task: { taskId: string; status: string; [key: string]: unknown },
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify(task, null, 2);
-  }
+  return formatOutput(
+    task,
+    () => {
+      const statusColor = (s: string) => {
+        switch (s) {
+          case "completed":
+            return green(s);
+          case "working":
+            return yellow(s);
+          case "failed":
+          case "cancelled":
+            return red(s);
+          case "input_required":
+            return yellow(s);
+          default:
+            return s;
+        }
+      };
 
-  const statusColor = (s: string) => {
-    switch (s) {
-      case "completed":
-        return green(s);
-      case "working":
-        return yellow(s);
-      case "failed":
-      case "cancelled":
-        return red(s);
-      case "input_required":
-        return yellow(s);
-      default:
-        return s;
-    }
-  };
-
-  const lines: string[] = [];
-  lines.push(`${bold("Task:")} ${cyan(task.taskId)}`);
-  lines.push(`${bold("Status:")} ${statusColor(task.status)}`);
-  if (task.statusMessage) lines.push(`${bold("Message:")} ${dim(String(task.statusMessage))}`);
-  if (task.createdAt) lines.push(`${bold("Created:")} ${dim(String(task.createdAt))}`);
-  if (task.lastUpdatedAt) lines.push(`${bold("Updated:")} ${dim(String(task.lastUpdatedAt))}`);
-  if (task.ttl != null) lines.push(`${bold("TTL:")} ${dim(String(task.ttl) + "ms")}`);
-  if (task.pollInterval != null)
-    lines.push(`${bold("Poll interval:")} ${dim(String(task.pollInterval) + "ms")}`);
-  return lines.join("\n");
+      const lines: string[] = [];
+      lines.push(`${bold("Task:")} ${cyan(task.taskId)}`);
+      lines.push(`${bold("Status:")} ${statusColor(task.status)}`);
+      if (task.statusMessage) lines.push(`${bold("Message:")} ${dim(String(task.statusMessage))}`);
+      if (task.createdAt) lines.push(`${bold("Created:")} ${dim(String(task.createdAt))}`);
+      if (task.lastUpdatedAt) lines.push(`${bold("Updated:")} ${dim(String(task.lastUpdatedAt))}`);
+      if (task.ttl != null) lines.push(`${bold("TTL:")} ${dim(String(task.ttl) + "ms")}`);
+      if (task.pollInterval != null)
+        lines.push(`${bold("Poll interval:")} ${dim(String(task.pollInterval) + "ms")}`);
+      return lines.join("\n");
+    },
+    options,
+  );
 }
 
 /** Format a list of tasks */
@@ -825,43 +681,45 @@ export function formatTasksList(
   nextCursor: string | undefined,
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify({ tasks, ...(nextCursor ? { nextCursor } : {}) }, null, 2);
-  }
+  return formatOutput(
+    { tasks, ...(nextCursor ? { nextCursor } : {}) },
+    () => {
+      if (tasks.length === 0) {
+        return dim("No tasks found");
+      }
 
-  if (tasks.length === 0) {
-    return dim("No tasks found");
-  }
+      const statusColor = (s: string) => {
+        switch (s) {
+          case "completed":
+            return green(s.padEnd(14));
+          case "working":
+            return yellow(s.padEnd(14));
+          case "failed":
+          case "cancelled":
+            return red(s.padEnd(14));
+          default:
+            return s.padEnd(14);
+        }
+      };
 
-  const statusColor = (s: string) => {
-    switch (s) {
-      case "completed":
-        return green(s.padEnd(14));
-      case "working":
-        return yellow(s.padEnd(14));
-      case "failed":
-      case "cancelled":
-        return red(s.padEnd(14));
-      default:
-        return s.padEnd(14);
-    }
-  };
+      const maxId = Math.max(...tasks.map((t) => t.taskId.length));
 
-  const maxId = Math.max(...tasks.map((t) => t.taskId.length));
+      const lines = tasks.map((t) => {
+        const id = cyan(t.taskId.padEnd(maxId));
+        const status = statusColor(t.status);
+        const updated = t.lastUpdatedAt ? dim(String(t.lastUpdatedAt)) : "";
+        return `${id}  ${status}  ${updated}`;
+      });
 
-  const lines = tasks.map((t) => {
-    const id = cyan(t.taskId.padEnd(maxId));
-    const status = statusColor(t.status);
-    const updated = t.lastUpdatedAt ? dim(String(t.lastUpdatedAt)) : "";
-    return `${id}  ${status}  ${updated}`;
-  });
+      if (nextCursor) {
+        lines.push("");
+        lines.push(dim(`Next cursor: ${nextCursor}`));
+      }
 
-  if (nextCursor) {
-    lines.push("");
-    lines.push(dim(`Next cursor: ${nextCursor}`));
-  }
-
-  return lines.join("\n");
+      return lines.join("\n");
+    },
+    options,
+  );
 }
 
 /** Format task creation output (for --no-wait) */
@@ -869,16 +727,14 @@ export function formatTaskCreated(
   task: { taskId: string; status: string; [key: string]: unknown },
   options: FormatOptions,
 ): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify({ task }, null, 2);
-  }
-  return `${green("Task created:")} ${cyan(task.taskId)} ${dim(`(status: ${task.status})`)}`;
+  return formatOutput(
+    { task },
+    () => `${green("Task created:")} ${cyan(task.taskId)} ${dim(`(status: ${task.status})`)}`,
+    options,
+  );
 }
 
 /** Format an error message */
 export function formatError(message: string, options: FormatOptions): string {
-  if (!isInteractive(options)) {
-    return JSON.stringify({ error: message });
-  }
-  return `${red("error:")} ${message}`;
+  return formatOutput({ error: message }, () => `${red("error:")} ${message}`, options);
 }

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -607,12 +607,10 @@ export function formatPromptMessages(
 
 /** Format a unified list of tools, resources, and prompts across servers */
 export function formatUnifiedList(items: UnifiedItem[], options: FormatOptions): string {
-  const typeLabel = (t: UnifiedItem["type"]) => {
-    const maxType = 8; // "resource" is the longest at 8 chars
-    const padded = t.padEnd(maxType);
-    if (t === "tool") return green(padded);
-    if (t === "resource") return cyan(padded);
-    return yellow(padded);
+  const typeLabel = (t: string) => {
+    if (t === "tool") return green(t);
+    if (t === "resource") return cyan(t);
+    return yellow(t);
   };
 
   return formatOutput(

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,6 +1,7 @@
 import type { SearchIndex } from "../config/schemas.ts";
 import { keywordSearch } from "./keyword.ts";
 import { semanticSearch } from "./semantic.ts";
+import { DEFAULTS } from "../constants.ts";
 
 export interface SearchResult {
   server: string;
@@ -22,7 +23,7 @@ export async function search(
   index: SearchIndex,
   options: SearchOptions = {},
 ): Promise<SearchResult[]> {
-  const topK = options.topK ?? 10;
+  const topK = options.topK ?? DEFAULTS.SEARCH_TOP_K;
   const results = new Map<string, SearchResult>();
 
   const runKeyword = !options.semanticOnly;

--- a/src/search/keyword.ts
+++ b/src/search/keyword.ts
@@ -1,11 +1,8 @@
 import picomatch from "picomatch";
 import type { IndexedTool } from "../config/schemas.ts";
+import type { BaseMatch } from "./types.ts";
 
-export interface KeywordMatch {
-  server: string;
-  tool: string;
-  description: string;
-  score: number;
+export interface KeywordMatch extends BaseMatch {
   matchedField: string;
 }
 

--- a/src/search/semantic.ts
+++ b/src/search/semantic.ts
@@ -1,11 +1,8 @@
 import type { IndexedTool } from "../config/schemas.ts";
+import { DEFAULTS } from "../constants.ts";
+import type { BaseMatch } from "./types.ts";
 
-export interface SemanticMatch {
-  server: string;
-  tool: string;
-  description: string;
-  score: number;
-}
+export type SemanticMatch = BaseMatch;
 
 // Lazy-loaded pipeline singleton
 let pipelineInstance: ((text: string) => Promise<Float32Array>) | null = null;
@@ -56,7 +53,7 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 export async function semanticSearch(
   query: string,
   tools: IndexedTool[],
-  topK = 10,
+  topK = DEFAULTS.SEARCH_TOP_K,
 ): Promise<SemanticMatch[]> {
   // Only search tools that have embeddings
   const withEmbeddings = tools.filter((t) => t.embedding.length > 0);

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -1,0 +1,7 @@
+/** Base interface for tool search matches */
+export interface BaseMatch {
+  server: string;
+  tool: string;
+  description: string;
+  score: number;
+}

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -16,18 +16,12 @@ export interface ValidationResult {
   errors: ValidationError[];
 }
 
-/** Validate tool arguments against the tool's inputSchema */
-export function validateToolInput(
-  serverName: string,
-  tool: Tool,
+/** Compile (or retrieve from cache), validate, and return result */
+function validateWithSchema(
+  cacheKey: string,
+  schema: Record<string, unknown>,
   input: Record<string, unknown>,
 ): ValidationResult {
-  const schema = tool.inputSchema;
-  if (!schema || Object.keys(schema).length === 0) {
-    return { valid: true, errors: [] };
-  }
-
-  const cacheKey = `${serverName}/${tool.name}`;
   let validate = validatorCache.get(cacheKey);
 
   if (!validate) {
@@ -35,7 +29,6 @@ export function validateToolInput(
       validate = ajv.compile(schema);
       validatorCache.set(cacheKey, validate);
     } catch {
-      // If schema can't be compiled, skip validation
       return { valid: true, errors: [] };
     }
   }
@@ -49,30 +42,25 @@ export function validateToolInput(
   return { valid: false, errors };
 }
 
+/** Validate tool arguments against the tool's inputSchema */
+export function validateToolInput(
+  serverName: string,
+  tool: Tool,
+  input: Record<string, unknown>,
+): ValidationResult {
+  const schema = tool.inputSchema;
+  if (!schema || Object.keys(schema).length === 0) {
+    return { valid: true, errors: [] };
+  }
+  return validateWithSchema(`${serverName}/${tool.name}`, schema, input);
+}
+
 /** Validate user-collected form data against an elicitation requestedSchema */
 export function validateElicitationResponse(
   schema: Record<string, unknown>,
   input: Record<string, unknown>,
 ): ValidationResult {
-  const cacheKey = `__elicitation__${JSON.stringify(schema)}`;
-  let validate = validatorCache.get(cacheKey);
-
-  if (!validate) {
-    try {
-      validate = ajv.compile(schema);
-      validatorCache.set(cacheKey, validate);
-    } catch {
-      return { valid: true, errors: [] };
-    }
-  }
-
-  const valid = validate(input);
-  if (valid) {
-    return { valid: true, errors: [] };
-  }
-
-  const errors = (validate.errors ?? []).map(formatAjvError);
-  return { valid: false, errors };
+  return validateWithSchema(`__elicitation__${JSON.stringify(schema)}`, schema, input);
 }
 
 function formatAjvError(err: ErrorObject): ValidationError {

--- a/test/client/sse.test.ts
+++ b/test/client/sse.test.ts
@@ -6,7 +6,7 @@ import type { HttpServerConfig } from "../../src/config/schemas.ts";
 describe("createSseTransport", () => {
   test("returns an SSEClientTransport instance", () => {
     const config: HttpServerConfig = { url: "https://example.com/sse" };
-    const transport = createSseTransport(config);
+    const transport = createSseTransport({ config });
     expect(transport).toBeInstanceOf(SSEClientTransport);
   });
 
@@ -15,7 +15,7 @@ describe("createSseTransport", () => {
       url: "https://example.com/sse",
       headers: { Authorization: "Bearer tok123" },
     };
-    const transport = createSseTransport(config);
+    const transport = createSseTransport({ config });
     expect(transport).toBeInstanceOf(SSEClientTransport);
   });
 
@@ -33,13 +33,13 @@ describe("createSseTransport", () => {
       saveTokens: () => Promise.resolve(),
       saveClientInformation: () => Promise.resolve(),
     };
-    const transport = createSseTransport(config, fakeProvider as any);
+    const transport = createSseTransport({ config, authProvider: fakeProvider as any });
     expect(transport).toBeInstanceOf(SSEClientTransport);
   });
 
   test("accepts verbose mode without errors", () => {
     const config: HttpServerConfig = { url: "https://example.com/sse" };
-    const transport = createSseTransport(config, undefined, true, false);
+    const transport = createSseTransport({ config, verbose: true, showSecrets: false });
     expect(transport).toBeInstanceOf(SSEClientTransport);
   });
 });


### PR DESCRIPTION
## Summary

Structural refactoring to reduce code duplication across the codebase (~230 net lines removed, 28 files touched). No behavioral changes — all 229 tests pass.

- **`src/constants.ts`** — Centralized env var names (`MCP_DEBUG`, `MCP_CONFIG_PATH`, etc.) and default values (concurrency, timeout, retries, TTL, search limit) previously scattered as magic strings/numbers across 7 files
- **`src/commands/with-command.ts`** — `withCommand()` wrapper that handles context setup, spinner management, error formatting, and `manager.close()` cleanup — replaces identical try/catch/finally boilerplate in 7 commands (list, info, resource, prompt, task, servers, index)
- **`src/output/format-output.ts`** / **`format-table.ts`** — Extracted `formatOutput()` (JSON/interactive branching) and `formatTable()` (column alignment + description wrapping) helpers, reducing `formatter.ts` from ~885 to ~650 lines
- **`src/client/transport-options.ts`** — Shared `buildTransportInit()` for HTTP and SSE transports, also fixes missing User-Agent header in SSE requests
- **`src/client/manager.ts`** — `callWithResilience()` combines the repeated `withRetry(getClient → withTimeout(call))` pattern used in 6 methods; `WithServer` base interface for the three `*WithServer` types
- **`src/validation/schema.ts`** — `validateWithSchema()` extracts shared compile-cache-validate logic from two functions
- **`src/search/types.ts`** — `BaseMatch` interface shared by `KeywordMatch` and `SemanticMatch`
- **`src/config/loader.ts`** — `saveJsonFile()` helper consolidates three identical save functions

## Test plan

- [x] All 229 existing tests pass (`bun test`)
- [x] Formatting clean (`bun run format` — no changes)
- [ ] Manual smoke test: `mcpx --json` and `mcpx info <server>` verify JSON and interactive output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)