### PR TITLE
Add granular tool authorization for Claude Code and Cursor (mcpx allow / mcpx deny)

### DIFF
--- a/.claude/skills/mcpx.md
+++ b/.claude/skills/mcpx.md
@@ -8,6 +8,26 @@ trigger: when the user wants to interact with external services, APIs, or MCP to
 
 You have access to external tools via `mcpx`. Use this workflow:
 
+## 0. Self-authorize (if needed)
+
+By default, Claude Code prompts the user for every `mcpx exec` call. If the user has approved `Bash(mcpx allow:*)` (you cannot do this yourself — the user must approve it when prompted), you can grant yourself granular permissions before executing:
+
+```bash
+mcpx allow <server> <tool>
+```
+
+This writes a specific pattern to `.claude/settings.local.json`. After that, `mcpx exec <server> <tool>` runs without prompting.
+
+For broader access:
+
+```bash
+mcpx allow <server>                # all tools on a server
+mcpx allow --all-read              # search, info, list, servers, ping, etc.
+mcpx allow --all                   # all mcpx exec calls
+```
+
+**Important:** If the user has not approved `Bash(mcpx allow:*)`, skip this step — Claude Code will prompt the user directly for each `mcpx exec` call instead.
+
 ## 1. Search for tools
 
 ```bash
@@ -146,6 +166,13 @@ mcpx deauth <server>           # remove stored auth
 | `mcpx task get <server> <taskId>`     | Get task status                   |
 | `mcpx task result <server> <taskId>`  | Retrieve completed task result    |
 | `mcpx task cancel <server> <taskId>`  | Cancel a running task             |
+| `mcpx allow <server>`                | Allow Claude Code to exec all tools on a server |
+| `mcpx allow <server> <tools...>`     | Allow specific tools only         |
+| `mcpx allow --all`                   | Allow all mcpx exec calls         |
+| `mcpx allow --all-read`              | Allow read-only commands          |
+| `mcpx allow --list`                  | Show current mcpx permissions     |
+| `mcpx deny <server>`                 | Remove server permissions         |
+| `mcpx deny --all`                    | Remove all mcpx permissions       |
 
 ## Global flags
 

--- a/.claude/skills/mcpx.md
+++ b/.claude/skills/mcpx.md
@@ -166,13 +166,15 @@ mcpx deauth <server>           # remove stored auth
 | `mcpx task get <server> <taskId>`     | Get task status                   |
 | `mcpx task result <server> <taskId>`  | Retrieve completed task result    |
 | `mcpx task cancel <server> <taskId>`  | Cancel a running task             |
-| `mcpx allow <server>`                | Allow Claude Code to exec all tools on a server |
+| `mcpx allow <server>`                | Allow agent to exec all tools on a server |
 | `mcpx allow <server> <tools...>`     | Allow specific tools only         |
 | `mcpx allow --all`                   | Allow all mcpx exec calls         |
 | `mcpx allow --all-read`              | Allow read-only commands          |
 | `mcpx allow --list`                  | Show current mcpx permissions     |
+| `mcpx allow --cursor <server>`       | Target Cursor instead of Claude   |
 | `mcpx deny <server>`                 | Remove server permissions         |
 | `mcpx deny --all`                    | Remove all mcpx permissions       |
+| `mcpx deny --cursor <server>`        | Target Cursor instead of Claude   |
 
 ## Global flags
 

--- a/.cursor/rules/mcpx.mdc
+++ b/.cursor/rules/mcpx.mdc
@@ -109,6 +109,22 @@ echo '{"action":"accept","content":{"confirm":true}}' | \
   mcpx exec my-server deploy_tool '{"target": "staging"}' --json
 ```
 
+## 6. Self-authorize (if needed)
+
+Cursor prompts you for every `mcpx exec` call. You can grant yourself granular permissions:
+
+```bash
+mcpx allow <server> --cursor              # all tools on a server
+mcpx allow <server> <tool> --cursor       # specific tool
+mcpx allow --all-read --cursor            # search, info, list, etc.
+mcpx allow --all --cursor                 # all mcpx exec calls
+mcpx allow --list --cursor                # show current permissions
+mcpx deny <server> --cursor               # revoke server permissions
+mcpx deny --all --cursor                  # revoke all permissions
+```
+
+This writes `Shell(mcpx exec:server:*)` patterns to `.cursor/cli.json`.
+
 ## Authentication
 
 Some HTTP servers require OAuth. If you see an "Not authenticated" error:
@@ -163,3 +179,10 @@ mcpx deauth <server>      # remove stored auth
 | `mcpx task get <server> <taskId>`    | Get task status                 |
 | `mcpx task result <server> <taskId>` | Retrieve completed task result  |
 | `mcpx task cancel <server> <taskId>` | Cancel a running task           |
+| `mcpx allow <server> --cursor`       | Allow exec all tools on a server |
+| `mcpx allow <server> <tools...> --cursor` | Allow specific tools only  |
+| `mcpx allow --all --cursor`          | Allow all mcpx exec calls       |
+| `mcpx allow --all-read --cursor`     | Allow read-only commands        |
+| `mcpx allow --list --cursor`         | Show current permissions        |
+| `mcpx deny <server> --cursor`        | Remove server permissions       |
+| `mcpx deny --all --cursor`           | Remove all mcpx permissions     |

--- a/README.md
+++ b/README.md
@@ -95,11 +95,12 @@ mcpx search -n 5 "manage pull requests"
 | `mcpx task get <server> <taskId>`      | Get task status                                        |
 | `mcpx task result <server> <taskId>`   | Retrieve completed task result                         |
 | `mcpx task cancel <server> <taskId>`   | Cancel a running task                                  |
-| `mcpx allow <server>`                  | Allow Claude Code to exec all tools on a server        |
+| `mcpx allow <server>`                  | Allow an agent to exec all tools on a server           |
 | `mcpx allow <server> <tools...>`       | Allow specific tools only                              |
 | `mcpx allow --all`                     | Allow all mcpx exec calls                              |
 | `mcpx allow --all-read`                | Allow read-only commands (search, info, list, etc.)    |
 | `mcpx allow --list`                    | Show current mcpx-related permissions                  |
+| `mcpx allow --cursor <server>`         | Allow for Cursor instead of Claude Code                |
 | `mcpx deny <server>`                   | Remove permissions for a server                        |
 | `mcpx deny --all`                      | Remove all mcpx-related permissions                    |
 
@@ -597,15 +598,18 @@ To execute tools:
 Always search before executing — don't assume tool names.
 ```
 
-## Permissions (Claude Code)
+## Permissions (Claude Code & Cursor)
 
-Claude Code prompts users to approve each `mcpx exec` call. `mcpx allow` and `mcpx deny` manage fine-grained permission rules so Claude Code can self-authorize specific tools without broad access.
+AI agents like Claude Code and Cursor prompt users to approve each `mcpx exec` call. `mcpx allow` and `mcpx deny` manage fine-grained permission rules so agents can self-authorize specific tools without broad access.
 
-**Key insight:** If the user allows `Bash(mcpx allow:*)` once (safe — it only writes to local settings files), Claude Code can then grant itself access to specific tools as needed. This is an opt-in workflow — by default, Claude Code cannot self-authorize and will prompt the user for each `mcpx exec` call.
+**Key insight:** If the user allows the initial permission pattern once (safe — it only writes to local settings files), the agent can then grant itself access to specific tools as needed. This is an opt-in workflow — by default, agents cannot self-authorize and will prompt the user for each `mcpx exec` call.
 
 ```bash
-# Allow all tools on a server
+# Allow all tools on a server (Claude Code, default)
 mcpx allow github
+
+# Allow for Cursor instead
+mcpx allow github --cursor
 
 # Allow specific tools only
 mcpx allow github search_repositories get_file
@@ -618,6 +622,7 @@ mcpx allow --all
 
 # Show current permissions across all scopes
 mcpx allow --list
+mcpx allow --list --cursor
 
 # Preview what would be written
 mcpx allow github --dry-run
@@ -629,13 +634,20 @@ mcpx deny github
 mcpx deny --all
 ```
 
+**Target flag** — by default, permissions target Claude Code. Use `--cursor` to target Cursor instead:
+
+| Flag        | Pattern prefix | Settings files                                  |
+| ----------- | -------------- | ----------------------------------------------- |
+| _(default)_ | `Bash(…)`      | `.claude/settings.local.json`, etc.             |
+| `--cursor`  | `Shell(…)`     | `.cursor/cli.json`, `~/.cursor/cli-config.json` |
+
 **Scope flags** control where the permission is written:
 
-| Flag        | File                          | Default |
-| ----------- | ----------------------------- | ------- |
-| `--local`   | `.claude/settings.local.json` | ✓       |
-| `--project` | `.claude/settings.json`       |         |
-| `--global`  | `~/.claude/settings.json`     |         |
+| Flag        | Claude Code file              | Cursor file                 | Default |
+| ----------- | ----------------------------- | --------------------------- | ------- |
+| `--local`   | `.claude/settings.local.json` | `.cursor/cli.json`          | ✓       |
+| `--project` | `.claude/settings.json`       | `.cursor/cli.json`          |         |
+| `--global`  | `~/.claude/settings.json`     | `~/.cursor/cli-config.json` |         |
 
 **`allow` options:**
 
@@ -644,21 +656,23 @@ mcpx deny --all
 | `--all`      | Allow all mcpx exec calls                           |
 | `--all-read` | Allow read-only commands (search, info, list, etc.) |
 | `--list`     | Show current mcpx-related permissions               |
-| `--local`    | Write to `.claude/settings.local.json` (default)    |
-| `--project`  | Write to `.claude/settings.json` (shared)           |
-| `--global`   | Write to `~/.claude/settings.json`                  |
+| `--cursor`   | Target Cursor settings instead of Claude Code       |
+| `--local`    | Write to local settings (default)                   |
+| `--project`  | Write to project settings (shared)                  |
+| `--global`   | Write to global settings                            |
 | `--dry-run`  | Show patterns without writing                       |
 
 **`deny` options:**
 
-| Flag         | Purpose                                          |
-| ------------ | ------------------------------------------------ |
-| `--all`      | Remove all mcpx-related permissions              |
-| `--all-read` | Remove read-only command permissions             |
-| `--local`    | Write to `.claude/settings.local.json` (default) |
-| `--project`  | Write to `.claude/settings.json` (shared)        |
-| `--global`   | Write to `~/.claude/settings.json`               |
-| `--dry-run`  | Show what would be removed                       |
+| Flag         | Purpose                                       |
+| ------------ | --------------------------------------------- |
+| `--all`      | Remove all mcpx-related permissions           |
+| `--all-read` | Remove read-only command permissions          |
+| `--cursor`   | Target Cursor settings instead of Claude Code |
+| `--local`    | Write to local settings (default)             |
+| `--project`  | Write to project settings (shared)            |
+| `--global`   | Write to global settings                      |
+| `--dry-run`  | Show what would be removed                    |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ mcpx search -n 5 "manage pull requests"
 | `mcpx task get <server> <taskId>`      | Get task status                                        |
 | `mcpx task result <server> <taskId>`   | Retrieve completed task result                         |
 | `mcpx task cancel <server> <taskId>`   | Cancel a running task                                  |
+| `mcpx allow <server>`                  | Allow Claude Code to exec all tools on a server        |
+| `mcpx allow <server> <tools...>`       | Allow specific tools only                              |
+| `mcpx allow --all`                     | Allow all mcpx exec calls                              |
+| `mcpx allow --all-read`                | Allow read-only commands (search, info, list, etc.)    |
+| `mcpx allow --list`                    | Show current mcpx-related permissions                  |
+| `mcpx deny <server>`                   | Remove permissions for a server                        |
+| `mcpx deny --all`                      | Remove all mcpx-related permissions                    |
 
 ## Options
 
@@ -589,6 +596,69 @@ To execute tools:
 
 Always search before executing — don't assume tool names.
 ```
+
+## Permissions (Claude Code)
+
+Claude Code prompts users to approve each `mcpx exec` call. `mcpx allow` and `mcpx deny` manage fine-grained permission rules so Claude Code can self-authorize specific tools without broad access.
+
+**Key insight:** If the user allows `Bash(mcpx allow:*)` once (safe — it only writes to local settings files), Claude Code can then grant itself access to specific tools as needed. This is an opt-in workflow — by default, Claude Code cannot self-authorize and will prompt the user for each `mcpx exec` call.
+
+```bash
+# Allow all tools on a server
+mcpx allow github
+
+# Allow specific tools only
+mcpx allow github search_repositories get_file
+
+# Allow read-only commands (search, info, list, servers, ping, etc.)
+mcpx allow --all-read
+
+# Allow all mcpx exec calls
+mcpx allow --all
+
+# Show current permissions across all scopes
+mcpx allow --list
+
+# Preview what would be written
+mcpx allow github --dry-run
+
+# Revoke a server's permissions
+mcpx deny github
+
+# Revoke all mcpx permissions
+mcpx deny --all
+```
+
+**Scope flags** control where the permission is written:
+
+| Flag        | File                          | Default |
+| ----------- | ----------------------------- | ------- |
+| `--local`   | `.claude/settings.local.json` | ✓       |
+| `--project` | `.claude/settings.json`       |         |
+| `--global`  | `~/.claude/settings.json`     |         |
+
+**`allow` options:**
+
+| Flag         | Purpose                                             |
+| ------------ | --------------------------------------------------- |
+| `--all`      | Allow all mcpx exec calls                           |
+| `--all-read` | Allow read-only commands (search, info, list, etc.) |
+| `--list`     | Show current mcpx-related permissions               |
+| `--local`    | Write to `.claude/settings.local.json` (default)    |
+| `--project`  | Write to `.claude/settings.json` (shared)           |
+| `--global`   | Write to `~/.claude/settings.json`                  |
+| `--dry-run`  | Show patterns without writing                       |
+
+**`deny` options:**
+
+| Flag         | Purpose                                          |
+| ------------ | ------------------------------------------------ |
+| `--all`      | Remove all mcpx-related permissions              |
+| `--all-read` | Remove read-only command permissions             |
+| `--local`    | Write to `.claude/settings.local.json` (default) |
+| `--project`  | Write to `.claude/settings.json` (shared)        |
+| `--global`   | Write to `~/.claude/settings.json`               |
+| `--dry-run`  | Show what would be removed                       |
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.15.9",
+  "version": "0.16.0",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,8 @@ import { registerResourceCommand } from "./commands/resource.ts";
 import { registerPromptCommand } from "./commands/prompt.ts";
 import { registerServersCommand } from "./commands/servers.ts";
 import { registerTaskCommand } from "./commands/task.ts";
+import { registerAllowCommand } from "./commands/allow.ts";
+import { registerDenyCommand } from "./commands/deny.ts";
 
 import pkg from "../package.json";
 
@@ -49,6 +51,8 @@ registerResourceCommand(program);
 registerPromptCommand(program);
 registerServersCommand(program);
 registerTaskCommand(program);
+registerAllowCommand(program);
+registerDenyCommand(program);
 
 // Detect unknown subcommands before commander misreports them as "too many arguments"
 const knownCommands = new Set(program.commands.map((c) => c.name()));

--- a/src/commands/allow.ts
+++ b/src/commands/allow.ts
@@ -1,0 +1,157 @@
+import type { Command } from "commander";
+import { bold, cyan, dim, green, yellow } from "ansis";
+import {
+  type Scope,
+  resolveSettingsPath,
+  readClaudeSettings,
+  writeClaudeSettings,
+  execPattern,
+  readOnlyPatterns,
+  allExecPattern,
+  allowCommandPattern,
+  denyCommandPattern,
+  addPatterns,
+  getMcpxPatterns,
+} from "../lib/claude-settings.ts";
+import { formatOutput } from "../output/format-output.ts";
+import type { FormatOptions } from "../output/formatter.ts";
+
+export function registerAllowCommand(program: Command) {
+  program
+    .command("allow")
+    .description("add Claude Code permission rules for mcpx commands")
+    .argument("[server]", "server name to allow")
+    .argument("[tools...]", "specific tool names to allow")
+    .option("--all", "allow all mcpx exec calls")
+    .option("--all-read", "allow read-only commands (search, info, list, servers, ping, etc.)")
+    .option("--list", "show current mcpx-related permissions")
+    .option("--local", "write to .claude/settings.local.json (default)")
+    .option("--project", "write to .claude/settings.json (shared)")
+    .option("--global", "write to ~/.claude/settings.json")
+    .option("--dry-run", "show patterns without writing")
+    .action(
+      async (
+        server: string | undefined,
+        tools: string[],
+        options: {
+          all?: boolean;
+          allRead?: boolean;
+          list?: boolean;
+          local?: boolean;
+          project?: boolean;
+          global?: boolean;
+          dryRun?: boolean;
+        },
+      ) => {
+        const formatOptions: FormatOptions = { json: program.opts().json };
+
+        // --list mode: show current permissions across all scopes
+        if (options.list) {
+          const scopes: Scope[] = ["local", "project", "global"];
+          const results: { scope: Scope; path: string; patterns: string[] }[] = [];
+
+          for (const scope of scopes) {
+            const path = resolveSettingsPath(scope);
+            const settings = await readClaudeSettings(path);
+            const patterns = getMcpxPatterns(settings);
+            results.push({ scope, path, patterns });
+          }
+
+          console.log(
+            formatOutput(
+              results.map((r) => ({ scope: r.scope, path: r.path, patterns: r.patterns })),
+              () => {
+                const lines: string[] = [];
+                for (const r of results) {
+                  lines.push(bold(`${r.scope}`) + dim(` (${r.path})`));
+                  if (r.patterns.length === 0) {
+                    lines.push(`  ${dim("(none)")}`);
+                  } else {
+                    for (const p of r.patterns) {
+                      lines.push(`  ${green("✓")} ${p}`);
+                    }
+                  }
+                  lines.push("");
+                }
+                return lines.join("\n").trimEnd();
+              },
+              formatOptions,
+            ),
+          );
+          return;
+        }
+
+        // Build the list of patterns to add
+        const patterns: string[] = [];
+
+        if (options.all) {
+          patterns.push(allExecPattern());
+        }
+
+        if (options.allRead) {
+          patterns.push(...readOnlyPatterns());
+        }
+
+        if (server && tools.length > 0) {
+          for (const tool of tools) {
+            patterns.push(execPattern(server, tool));
+          }
+        } else if (server) {
+          patterns.push(execPattern(server));
+        }
+
+        if (patterns.length === 0) {
+          console.error("error: specify a server, --all, or --all-read. See 'mcpx allow --help'.");
+          process.exit(1);
+        }
+
+        // Always include allow/deny command patterns so Claude can self-manage
+        patterns.push(allowCommandPattern());
+        patterns.push(denyCommandPattern());
+
+        const scope: Scope = options.global ? "global" : options.project ? "project" : "local";
+        const path = resolveSettingsPath(scope);
+
+        if (options.dryRun) {
+          console.log(
+            formatOutput(
+              { scope, path, patterns },
+              () => {
+                const lines: string[] = [];
+                lines.push(bold("Dry run") + dim(` — would write to ${path}:`));
+                for (const p of patterns) {
+                  lines.push(`  ${yellow("+")} ${p}`);
+                }
+                return lines.join("\n");
+              },
+              formatOptions,
+            ),
+          );
+          return;
+        }
+
+        const settings = await readClaudeSettings(path);
+        const { settings: updated, added } = addPatterns(settings, patterns);
+        await writeClaudeSettings(path, updated);
+
+        console.log(
+          formatOutput(
+            { scope, path, added, total: (updated.permissions?.allow ?? []).length },
+            () => {
+              const lines: string[] = [];
+              if (added.length === 0) {
+                lines.push(dim("All patterns already present — no changes."));
+              } else {
+                lines.push(bold(`Added ${added.length} permission(s)`) + dim(` → ${path}`));
+                for (const p of added) {
+                  lines.push(`  ${green("+")} ${p}`);
+                }
+              }
+              return lines.join("\n");
+            },
+            formatOptions,
+          ),
+        );
+      },
+    );
+}

--- a/src/commands/allow.ts
+++ b/src/commands/allow.ts
@@ -1,10 +1,11 @@
 import type { Command } from "commander";
 import { bold, cyan, dim, green, yellow } from "ansis";
 import {
+  type Client,
   type Scope,
   resolveSettingsPath,
-  readClaudeSettings,
-  writeClaudeSettings,
+  readClientSettings,
+  writeClientSettings,
   execPattern,
   readOnlyPatterns,
   allExecPattern,
@@ -12,22 +13,23 @@ import {
   denyCommandPattern,
   addPatterns,
   getMcpxPatterns,
-} from "../lib/claude-settings.ts";
+} from "../lib/client-settings.ts";
 import { formatOutput } from "../output/format-output.ts";
 import type { FormatOptions } from "../output/formatter.ts";
 
 export function registerAllowCommand(program: Command) {
   program
     .command("allow")
-    .description("add Claude Code permission rules for mcpx commands")
+    .description("add permission rules for mcpx commands (Claude Code or Cursor)")
     .argument("[server]", "server name to allow")
     .argument("[tools...]", "specific tool names to allow")
     .option("--all", "allow all mcpx exec calls")
     .option("--all-read", "allow read-only commands (search, info, list, servers, ping, etc.)")
     .option("--list", "show current mcpx-related permissions")
-    .option("--local", "write to .claude/settings.local.json (default)")
-    .option("--project", "write to .claude/settings.json (shared)")
-    .option("--global", "write to ~/.claude/settings.json")
+    .option("--cursor", "target Cursor settings instead of Claude Code")
+    .option("--local", "write to local settings (default)")
+    .option("--project", "write to project settings (shared)")
+    .option("--global", "write to global settings")
     .option("--dry-run", "show patterns without writing")
     .action(
       async (
@@ -37,6 +39,7 @@ export function registerAllowCommand(program: Command) {
           all?: boolean;
           allRead?: boolean;
           list?: boolean;
+          cursor?: boolean;
           local?: boolean;
           project?: boolean;
           global?: boolean;
@@ -44,16 +47,19 @@ export function registerAllowCommand(program: Command) {
         },
       ) => {
         const formatOptions: FormatOptions = { json: program.opts().json };
+        const client: Client = options.cursor ? "cursor" : "claude";
 
         // --list mode: show current permissions across all scopes
         if (options.list) {
-          const scopes: Scope[] = ["local", "project", "global"];
+          // Cursor maps local and project to the same file, so only show unique scopes
+          const scopes: Scope[] =
+            client === "cursor" ? ["local", "global"] : ["local", "project", "global"];
           const results: { scope: Scope; path: string; patterns: string[] }[] = [];
 
           for (const scope of scopes) {
-            const path = resolveSettingsPath(scope);
-            const settings = await readClaudeSettings(path);
-            const patterns = getMcpxPatterns(settings);
+            const path = resolveSettingsPath(scope, client);
+            const settings = await readClientSettings(path);
+            const patterns = getMcpxPatterns(settings, client);
             results.push({ scope, path, patterns });
           }
 
@@ -85,19 +91,19 @@ export function registerAllowCommand(program: Command) {
         const patterns: string[] = [];
 
         if (options.all) {
-          patterns.push(allExecPattern());
+          patterns.push(allExecPattern(client));
         }
 
         if (options.allRead) {
-          patterns.push(...readOnlyPatterns());
+          patterns.push(...readOnlyPatterns(client));
         }
 
         if (server && tools.length > 0) {
           for (const tool of tools) {
-            patterns.push(execPattern(server, tool));
+            patterns.push(execPattern(server, tool, client));
           }
         } else if (server) {
-          patterns.push(execPattern(server));
+          patterns.push(execPattern(server, undefined, client));
         }
 
         if (patterns.length === 0) {
@@ -105,12 +111,12 @@ export function registerAllowCommand(program: Command) {
           process.exit(1);
         }
 
-        // Always include allow/deny command patterns so Claude can self-manage
-        patterns.push(allowCommandPattern());
-        patterns.push(denyCommandPattern());
+        // Always include allow/deny command patterns so the agent can self-manage
+        patterns.push(allowCommandPattern(client));
+        patterns.push(denyCommandPattern(client));
 
         const scope: Scope = options.global ? "global" : options.project ? "project" : "local";
-        const path = resolveSettingsPath(scope);
+        const path = resolveSettingsPath(scope, client);
 
         if (options.dryRun) {
           console.log(
@@ -130,9 +136,9 @@ export function registerAllowCommand(program: Command) {
           return;
         }
 
-        const settings = await readClaudeSettings(path);
+        const settings = await readClientSettings(path);
         const { settings: updated, added } = addPatterns(settings, patterns);
-        await writeClaudeSettings(path, updated);
+        await writeClientSettings(path, updated);
 
         console.log(
           formatOutput(

--- a/src/commands/deny.ts
+++ b/src/commands/deny.ts
@@ -1,0 +1,130 @@
+import type { Command } from "commander";
+import { bold, dim, green, red, yellow } from "ansis";
+import {
+  type Scope,
+  resolveSettingsPath,
+  readClaudeSettings,
+  writeClaudeSettings,
+  execPattern,
+  readOnlyPatterns,
+  allExecPattern,
+  removePatterns,
+  removeAllMcpxPatterns,
+  getServerPatterns,
+} from "../lib/claude-settings.ts";
+import { formatOutput } from "../output/format-output.ts";
+import type { FormatOptions } from "../output/formatter.ts";
+
+export function registerDenyCommand(program: Command) {
+  program
+    .command("deny")
+    .description("remove Claude Code permission rules for mcpx commands")
+    .argument("[server]", "server name to deny")
+    .argument("[tools...]", "specific tool names to deny")
+    .option("--all", "remove all mcpx-related permissions")
+    .option("--all-read", "remove read-only command permissions")
+    .option("--local", "write to .claude/settings.local.json (default)")
+    .option("--project", "write to .claude/settings.json (shared)")
+    .option("--global", "write to ~/.claude/settings.json")
+    .option("--dry-run", "show what would be removed")
+    .action(
+      async (
+        server: string | undefined,
+        tools: string[],
+        options: {
+          all?: boolean;
+          allRead?: boolean;
+          local?: boolean;
+          project?: boolean;
+          global?: boolean;
+          dryRun?: boolean;
+        },
+      ) => {
+        const formatOptions: FormatOptions = { json: program.opts().json };
+        const scope: Scope = options.global ? "global" : options.project ? "project" : "local";
+        const path = resolveSettingsPath(scope);
+        const settings = await readClaudeSettings(path);
+
+        let result: { settings: typeof settings; removed: string[] };
+
+        if (options.all) {
+          // Remove all mcpx-related patterns
+          result = removeAllMcpxPatterns(settings);
+        } else {
+          // Build the list of patterns to remove
+          const patterns: string[] = [];
+
+          if (options.allRead) {
+            patterns.push(...readOnlyPatterns());
+          }
+
+          if (server && tools.length > 0) {
+            for (const tool of tools) {
+              patterns.push(execPattern(server, tool));
+            }
+          } else if (server) {
+            // Remove the server-level pattern AND all tool-specific patterns for this server
+            patterns.push(execPattern(server));
+            patterns.push(...getServerPatterns(settings, server));
+          }
+
+          if (patterns.length === 0) {
+            console.error("error: specify a server, --all, or --all-read. See 'mcpx deny --help'.");
+            process.exit(1);
+          }
+
+          result = removePatterns(settings, patterns);
+        }
+
+        if (options.dryRun) {
+          console.log(
+            formatOutput(
+              { scope, path, wouldRemove: result.removed },
+              () => {
+                const lines: string[] = [];
+                lines.push(bold("Dry run") + dim(` — would remove from ${path}:`));
+                if (result.removed.length === 0) {
+                  lines.push(`  ${dim("(no matching patterns found)")}`);
+                } else {
+                  for (const p of result.removed) {
+                    lines.push(`  ${yellow("-")} ${p}`);
+                  }
+                }
+                return lines.join("\n");
+              },
+              formatOptions,
+            ),
+          );
+          return;
+        }
+
+        await writeClaudeSettings(path, result.settings);
+
+        console.log(
+          formatOutput(
+            {
+              scope,
+              path,
+              removed: result.removed,
+              total: (result.settings.permissions?.allow ?? []).length,
+            },
+            () => {
+              const lines: string[] = [];
+              if (result.removed.length === 0) {
+                lines.push(dim("No matching patterns found — no changes."));
+              } else {
+                lines.push(
+                  bold(`Removed ${result.removed.length} permission(s)`) + dim(` → ${path}`),
+                );
+                for (const p of result.removed) {
+                  lines.push(`  ${red("-")} ${p}`);
+                }
+              }
+              return lines.join("\n");
+            },
+            formatOptions,
+          ),
+        );
+      },
+    );
+}

--- a/src/commands/deny.ts
+++ b/src/commands/deny.ts
@@ -1,31 +1,33 @@
 import type { Command } from "commander";
 import { bold, dim, green, red, yellow } from "ansis";
 import {
+  type Client,
   type Scope,
   resolveSettingsPath,
-  readClaudeSettings,
-  writeClaudeSettings,
+  readClientSettings,
+  writeClientSettings,
   execPattern,
   readOnlyPatterns,
   allExecPattern,
   removePatterns,
   removeAllMcpxPatterns,
   getServerPatterns,
-} from "../lib/claude-settings.ts";
+} from "../lib/client-settings.ts";
 import { formatOutput } from "../output/format-output.ts";
 import type { FormatOptions } from "../output/formatter.ts";
 
 export function registerDenyCommand(program: Command) {
   program
     .command("deny")
-    .description("remove Claude Code permission rules for mcpx commands")
+    .description("remove permission rules for mcpx commands (Claude Code or Cursor)")
     .argument("[server]", "server name to deny")
     .argument("[tools...]", "specific tool names to deny")
     .option("--all", "remove all mcpx-related permissions")
     .option("--all-read", "remove read-only command permissions")
-    .option("--local", "write to .claude/settings.local.json (default)")
-    .option("--project", "write to .claude/settings.json (shared)")
-    .option("--global", "write to ~/.claude/settings.json")
+    .option("--cursor", "target Cursor settings instead of Claude Code")
+    .option("--local", "write to local settings (default)")
+    .option("--project", "write to project settings (shared)")
+    .option("--global", "write to global settings")
     .option("--dry-run", "show what would be removed")
     .action(
       async (
@@ -34,6 +36,7 @@ export function registerDenyCommand(program: Command) {
         options: {
           all?: boolean;
           allRead?: boolean;
+          cursor?: boolean;
           local?: boolean;
           project?: boolean;
           global?: boolean;
@@ -41,31 +44,32 @@ export function registerDenyCommand(program: Command) {
         },
       ) => {
         const formatOptions: FormatOptions = { json: program.opts().json };
+        const client: Client = options.cursor ? "cursor" : "claude";
         const scope: Scope = options.global ? "global" : options.project ? "project" : "local";
-        const path = resolveSettingsPath(scope);
-        const settings = await readClaudeSettings(path);
+        const path = resolveSettingsPath(scope, client);
+        const settings = await readClientSettings(path);
 
         let result: { settings: typeof settings; removed: string[] };
 
         if (options.all) {
           // Remove all mcpx-related patterns
-          result = removeAllMcpxPatterns(settings);
+          result = removeAllMcpxPatterns(settings, client);
         } else {
           // Build the list of patterns to remove
           const patterns: string[] = [];
 
           if (options.allRead) {
-            patterns.push(...readOnlyPatterns());
+            patterns.push(...readOnlyPatterns(client));
           }
 
           if (server && tools.length > 0) {
             for (const tool of tools) {
-              patterns.push(execPattern(server, tool));
+              patterns.push(execPattern(server, tool, client));
             }
           } else if (server) {
             // Remove the server-level pattern AND all tool-specific patterns for this server
-            patterns.push(execPattern(server));
-            patterns.push(...getServerPatterns(settings, server));
+            patterns.push(execPattern(server, undefined, client));
+            patterns.push(...getServerPatterns(settings, server, client));
           }
 
           if (patterns.length === 0) {
@@ -98,7 +102,7 @@ export function registerDenyCommand(program: Command) {
           return;
         }
 
-        await writeClaudeSettings(path, result.settings);
+        await writeClientSettings(path, result.settings);
 
         console.log(
           formatOutput(

--- a/src/lib/claude-settings.ts
+++ b/src/lib/claude-settings.ts
@@ -1,0 +1,185 @@
+import { join } from "path";
+import { homedir } from "os";
+import { readFile, mkdir, writeFile } from "fs/promises";
+
+export type Scope = "local" | "project" | "global";
+
+interface ClaudeSettings {
+  permissions?: {
+    allow?: string[];
+    deny?: string[];
+  };
+  [key: string]: unknown;
+}
+
+/** Resolve the settings file path for a given scope */
+export function resolveSettingsPath(scope: Scope): string {
+  switch (scope) {
+    case "local":
+      return join(process.cwd(), ".claude", "settings.local.json");
+    case "project":
+      return join(process.cwd(), ".claude", "settings.json");
+    case "global":
+      return join(homedir(), ".claude", "settings.json");
+  }
+}
+
+/** Read Claude settings from a file, returning empty settings if the file doesn't exist */
+export async function readClaudeSettings(path: string): Promise<ClaudeSettings> {
+  try {
+    const content = await readFile(path, "utf-8");
+    return JSON.parse(content) as ClaudeSettings;
+  } catch {
+    return {};
+  }
+}
+
+/** Write Claude settings to a file, creating parent directories as needed */
+export async function writeClaudeSettings(path: string, settings: ClaudeSettings): Promise<void> {
+  const dir = join(path, "..");
+  await mkdir(dir, { recursive: true });
+  await writeFile(path, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+}
+
+/** Generate a Bash permission pattern for mcpx exec with a specific server and optional tool */
+export function execPattern(server: string, tool?: string): string {
+  if (tool) {
+    return `Bash(mcpx exec:${server}:${tool}:*)`;
+  }
+  return `Bash(mcpx exec:${server}:*)`;
+}
+
+/** Read-only mcpx commands that are safe to allow broadly */
+const READ_ONLY_COMMANDS = [
+  "search",
+  "info",
+  "servers",
+  "ping",
+  "resource",
+  "prompt",
+  "task",
+  "index",
+];
+
+/** Generate patterns for all read-only mcpx commands */
+export function readOnlyPatterns(): string[] {
+  return READ_ONLY_COMMANDS.map((cmd) => `Bash(mcpx ${cmd}:*)`);
+}
+
+/** Generate the broad allow-all pattern for mcpx exec */
+export function allExecPattern(): string {
+  return "Bash(mcpx exec:*)";
+}
+
+/** Generate the allow pattern for mcpx allow itself */
+export function allowCommandPattern(): string {
+  return "Bash(mcpx allow:*)";
+}
+
+/** Generate the allow pattern for mcpx deny itself */
+export function denyCommandPattern(): string {
+  return "Bash(mcpx deny:*)";
+}
+
+/** Check if a permission pattern is mcpx-related */
+export function isMcpxPattern(pattern: string): boolean {
+  return pattern.startsWith("Bash(mcpx ");
+}
+
+/** Add patterns to settings, deduplicating. Returns the updated settings and list of newly added patterns. */
+export function addPatterns(
+  settings: ClaudeSettings,
+  patterns: string[],
+): { settings: ClaudeSettings; added: string[] } {
+  const existing = new Set(settings.permissions?.allow ?? []);
+  const added: string[] = [];
+
+  for (const p of patterns) {
+    if (!existing.has(p)) {
+      existing.add(p);
+      added.push(p);
+    }
+  }
+
+  return {
+    settings: {
+      ...settings,
+      permissions: {
+        ...settings.permissions,
+        allow: [...existing],
+      },
+    },
+    added,
+  };
+}
+
+/** Remove specific patterns from settings. Returns the updated settings and list of removed patterns. */
+export function removePatterns(
+  settings: ClaudeSettings,
+  patterns: string[],
+): { settings: ClaudeSettings; removed: string[] } {
+  const existing = settings.permissions?.allow ?? [];
+  const toRemove = new Set(patterns);
+  const removed: string[] = [];
+  const remaining: string[] = [];
+
+  for (const p of existing) {
+    if (toRemove.has(p)) {
+      removed.push(p);
+    } else {
+      remaining.push(p);
+    }
+  }
+
+  return {
+    settings: {
+      ...settings,
+      permissions: {
+        ...settings.permissions,
+        allow: remaining,
+      },
+    },
+    removed,
+  };
+}
+
+/** Remove all mcpx-related patterns from settings. Returns the updated settings and list of removed patterns. */
+export function removeAllMcpxPatterns(settings: ClaudeSettings): {
+  settings: ClaudeSettings;
+  removed: string[];
+} {
+  const existing = settings.permissions?.allow ?? [];
+  const removed: string[] = [];
+  const remaining: string[] = [];
+
+  for (const p of existing) {
+    if (isMcpxPattern(p)) {
+      removed.push(p);
+    } else {
+      remaining.push(p);
+    }
+  }
+
+  return {
+    settings: {
+      ...settings,
+      permissions: {
+        ...settings.permissions,
+        allow: remaining,
+      },
+    },
+    removed,
+  };
+}
+
+/** Extract all mcpx-related patterns from settings */
+export function getMcpxPatterns(settings: ClaudeSettings): string[] {
+  return (settings.permissions?.allow ?? []).filter(isMcpxPattern);
+}
+
+/** Get all mcpx-related patterns for a specific server */
+export function getServerPatterns(settings: ClaudeSettings, server: string): string[] {
+  return getMcpxPatterns(settings).filter(
+    (p) => p.startsWith(`Bash(mcpx exec:${server}:`) || p === `Bash(mcpx exec:${server}:*)`,
+  );
+}

--- a/src/lib/client-settings.ts
+++ b/src/lib/client-settings.ts
@@ -2,9 +2,10 @@ import { join } from "path";
 import { homedir } from "os";
 import { readFile, mkdir, writeFile } from "fs/promises";
 
+export type Client = "claude" | "cursor";
 export type Scope = "local" | "project" | "global";
 
-interface ClaudeSettings {
+export interface ClientSettings {
   permissions?: {
     allow?: string[];
     deny?: string[];
@@ -12,8 +13,22 @@ interface ClaudeSettings {
   [key: string]: unknown;
 }
 
-/** Resolve the settings file path for a given scope */
-export function resolveSettingsPath(scope: Scope): string {
+function prefix(client: Client): string {
+  return client === "claude" ? "Bash" : "Shell";
+}
+
+/** Resolve the settings file path for a given scope and client */
+export function resolveSettingsPath(scope: Scope, client: Client = "claude"): string {
+  if (client === "cursor") {
+    switch (scope) {
+      case "local":
+      case "project":
+        return join(process.cwd(), ".cursor", "cli.json");
+      case "global":
+        return join(homedir(), ".cursor", "cli-config.json");
+    }
+  }
+
   switch (scope) {
     case "local":
       return join(process.cwd(), ".claude", "settings.local.json");
@@ -24,29 +39,30 @@ export function resolveSettingsPath(scope: Scope): string {
   }
 }
 
-/** Read Claude settings from a file, returning empty settings if the file doesn't exist */
-export async function readClaudeSettings(path: string): Promise<ClaudeSettings> {
+/** Read client settings from a file, returning empty settings if the file doesn't exist */
+export async function readClientSettings(path: string): Promise<ClientSettings> {
   try {
     const content = await readFile(path, "utf-8");
-    return JSON.parse(content) as ClaudeSettings;
+    return JSON.parse(content) as ClientSettings;
   } catch {
     return {};
   }
 }
 
-/** Write Claude settings to a file, creating parent directories as needed */
-export async function writeClaudeSettings(path: string, settings: ClaudeSettings): Promise<void> {
+/** Write client settings to a file, creating parent directories as needed */
+export async function writeClientSettings(path: string, settings: ClientSettings): Promise<void> {
   const dir = join(path, "..");
   await mkdir(dir, { recursive: true });
   await writeFile(path, JSON.stringify(settings, null, 2) + "\n", "utf-8");
 }
 
-/** Generate a Bash permission pattern for mcpx exec with a specific server and optional tool */
-export function execPattern(server: string, tool?: string): string {
+/** Generate a permission pattern for mcpx exec with a specific server and optional tool */
+export function execPattern(server: string, tool?: string, client: Client = "claude"): string {
+  const p = prefix(client);
   if (tool) {
-    return `Bash(mcpx exec:${server}:${tool}:*)`;
+    return `${p}(mcpx exec:${server}:${tool}:*)`;
   }
-  return `Bash(mcpx exec:${server}:*)`;
+  return `${p}(mcpx exec:${server}:*)`;
 }
 
 /** Read-only mcpx commands that are safe to allow broadly */
@@ -62,35 +78,36 @@ const READ_ONLY_COMMANDS = [
 ];
 
 /** Generate patterns for all read-only mcpx commands */
-export function readOnlyPatterns(): string[] {
-  return READ_ONLY_COMMANDS.map((cmd) => `Bash(mcpx ${cmd}:*)`);
+export function readOnlyPatterns(client: Client = "claude"): string[] {
+  const p = prefix(client);
+  return READ_ONLY_COMMANDS.map((cmd) => `${p}(mcpx ${cmd}:*)`);
 }
 
 /** Generate the broad allow-all pattern for mcpx exec */
-export function allExecPattern(): string {
-  return "Bash(mcpx exec:*)";
+export function allExecPattern(client: Client = "claude"): string {
+  return `${prefix(client)}(mcpx exec:*)`;
 }
 
 /** Generate the allow pattern for mcpx allow itself */
-export function allowCommandPattern(): string {
-  return "Bash(mcpx allow:*)";
+export function allowCommandPattern(client: Client = "claude"): string {
+  return `${prefix(client)}(mcpx allow:*)`;
 }
 
 /** Generate the allow pattern for mcpx deny itself */
-export function denyCommandPattern(): string {
-  return "Bash(mcpx deny:*)";
+export function denyCommandPattern(client: Client = "claude"): string {
+  return `${prefix(client)}(mcpx deny:*)`;
 }
 
 /** Check if a permission pattern is mcpx-related */
-export function isMcpxPattern(pattern: string): boolean {
-  return pattern.startsWith("Bash(mcpx ");
+export function isMcpxPattern(pattern: string, client: Client = "claude"): boolean {
+  return pattern.startsWith(`${prefix(client)}(mcpx `);
 }
 
 /** Add patterns to settings, deduplicating. Returns the updated settings and list of newly added patterns. */
 export function addPatterns(
-  settings: ClaudeSettings,
+  settings: ClientSettings,
   patterns: string[],
-): { settings: ClaudeSettings; added: string[] } {
+): { settings: ClientSettings; added: string[] } {
   const existing = new Set(settings.permissions?.allow ?? []);
   const added: string[] = [];
 
@@ -115,9 +132,9 @@ export function addPatterns(
 
 /** Remove specific patterns from settings. Returns the updated settings and list of removed patterns. */
 export function removePatterns(
-  settings: ClaudeSettings,
+  settings: ClientSettings,
   patterns: string[],
-): { settings: ClaudeSettings; removed: string[] } {
+): { settings: ClientSettings; removed: string[] } {
   const existing = settings.permissions?.allow ?? [];
   const toRemove = new Set(patterns);
   const removed: string[] = [];
@@ -144,8 +161,11 @@ export function removePatterns(
 }
 
 /** Remove all mcpx-related patterns from settings. Returns the updated settings and list of removed patterns. */
-export function removeAllMcpxPatterns(settings: ClaudeSettings): {
-  settings: ClaudeSettings;
+export function removeAllMcpxPatterns(
+  settings: ClientSettings,
+  client: Client = "claude",
+): {
+  settings: ClientSettings;
   removed: string[];
 } {
   const existing = settings.permissions?.allow ?? [];
@@ -153,7 +173,7 @@ export function removeAllMcpxPatterns(settings: ClaudeSettings): {
   const remaining: string[] = [];
 
   for (const p of existing) {
-    if (isMcpxPattern(p)) {
+    if (isMcpxPattern(p, client)) {
       removed.push(p);
     } else {
       remaining.push(p);
@@ -173,13 +193,18 @@ export function removeAllMcpxPatterns(settings: ClaudeSettings): {
 }
 
 /** Extract all mcpx-related patterns from settings */
-export function getMcpxPatterns(settings: ClaudeSettings): string[] {
-  return (settings.permissions?.allow ?? []).filter(isMcpxPattern);
+export function getMcpxPatterns(settings: ClientSettings, client: Client = "claude"): string[] {
+  return (settings.permissions?.allow ?? []).filter((p) => isMcpxPattern(p, client));
 }
 
 /** Get all mcpx-related patterns for a specific server */
-export function getServerPatterns(settings: ClaudeSettings, server: string): string[] {
-  return getMcpxPatterns(settings).filter(
-    (p) => p.startsWith(`Bash(mcpx exec:${server}:`) || p === `Bash(mcpx exec:${server}:*)`,
+export function getServerPatterns(
+  settings: ClientSettings,
+  server: string,
+  client: Client = "claude",
+): string[] {
+  const p = prefix(client);
+  return getMcpxPatterns(settings, client).filter(
+    (pat) => pat.startsWith(`${p}(mcpx exec:${server}:`) || pat === `${p}(mcpx exec:${server}:*)`,
   );
 }

--- a/test/commands/allow-deny.test.ts
+++ b/test/commands/allow-deny.test.ts
@@ -1,0 +1,278 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mkdtemp, rm, readFile, mkdir, writeFile } from "fs/promises";
+
+const CLI = join(import.meta.dir, "../../src/cli.ts");
+
+async function run(args: string[], cwd?: string) {
+  const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd,
+  });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  return { exitCode, stdout, stderr };
+}
+
+async function readSettings(dir: string, filename = "settings.local.json") {
+  const path = join(dir, ".claude", filename);
+  const content = await readFile(path, "utf-8");
+  return JSON.parse(content);
+}
+
+describe("mcpx allow", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mcpx-allow-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  test("errors without arguments", async () => {
+    const { exitCode, stderr } = await run(["allow"], tmpDir);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("specify a server");
+  });
+
+  test("allows a server", async () => {
+    const { exitCode } = await run(["allow", "github", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:github:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx allow:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx deny:*)");
+  });
+
+  test("allows specific tools", async () => {
+    const { exitCode } = await run(
+      ["allow", "github", "search_repositories", "get_file", "--json"],
+      tmpDir,
+    );
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:github:search_repositories:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:github:get_file:*)");
+    expect(settings.permissions.allow).not.toContain("Bash(mcpx exec:github:*)");
+  });
+
+  test("allows --all", async () => {
+    const { exitCode } = await run(["allow", "--all", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:*)");
+  });
+
+  test("allows --all-read", async () => {
+    const { exitCode } = await run(["allow", "--all-read", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Bash(mcpx search:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx info:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx servers:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx ping:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx resource:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx prompt:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx task:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx index:*)");
+  });
+
+  test("deduplicates patterns on repeated runs", async () => {
+    await run(["allow", "github", "--json"], tmpDir);
+    await run(["allow", "github", "--json"], tmpDir);
+
+    const settings = await readSettings(tmpDir);
+    const count = settings.permissions.allow.filter(
+      (p: string) => p === "Bash(mcpx exec:github:*)",
+    ).length;
+    expect(count).toBe(1);
+  });
+
+  test("preserves existing non-mcpx permissions", async () => {
+    const claudeDir = join(tmpDir, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(
+      join(claudeDir, "settings.local.json"),
+      JSON.stringify({
+        permissions: { allow: ["Bash(git:*)"] },
+      }),
+    );
+
+    await run(["allow", "github", "--json"], tmpDir);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Bash(git:*)");
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:github:*)");
+  });
+
+  test("dry-run does not write", async () => {
+    const { exitCode, stdout } = await run(["allow", "github", "--dry-run", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.patterns).toContain("Bash(mcpx exec:github:*)");
+
+    // File should not exist
+    try {
+      await readSettings(tmpDir);
+      throw new Error("expected file to not exist");
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message === "expected file to not exist") throw e;
+      // Expected — file doesn't exist
+    }
+  });
+
+  test("--list shows permissions as JSON", async () => {
+    await run(["allow", "github", "--json"], tmpDir);
+    const { exitCode, stdout } = await run(["allow", "--list", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    const local = parsed.find((r: { scope: string }) => r.scope === "local");
+    expect(local.patterns).toContain("Bash(mcpx exec:github:*)");
+  });
+
+  test("writes to project scope with --project", async () => {
+    const { exitCode } = await run(["allow", "github", "--project", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir, "settings.json");
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:github:*)");
+  });
+});
+
+describe("mcpx deny", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mcpx-deny-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  test("errors without arguments", async () => {
+    const { exitCode, stderr } = await run(["deny"], tmpDir);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("specify a server");
+  });
+
+  test("removes a server permission", async () => {
+    await run(["allow", "github", "--json"], tmpDir);
+
+    const settingsBefore = await readSettings(tmpDir);
+    expect(settingsBefore.permissions.allow).toContain("Bash(mcpx exec:github:*)");
+
+    const { exitCode } = await run(["deny", "github", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).not.toContain("Bash(mcpx exec:github:*)");
+  });
+
+  test("removes specific tool permissions", async () => {
+    await run(["allow", "github", "search_repositories", "get_file", "--json"], tmpDir);
+
+    const { exitCode } = await run(["deny", "github", "search_repositories", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).not.toContain(
+      "Bash(mcpx exec:github:search_repositories:*)",
+    );
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:github:get_file:*)");
+  });
+
+  test("removes server and all its tool patterns", async () => {
+    // Allow server-level + specific tools
+    await run(["allow", "github", "--json"], tmpDir);
+    await run(["allow", "github", "search_repositories", "--json"], tmpDir);
+
+    const { exitCode } = await run(["deny", "github", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    const githubPatterns = settings.permissions.allow.filter((p: string) =>
+      p.includes("mcpx exec:github"),
+    );
+    expect(githubPatterns.length).toBe(0);
+  });
+
+  test("--all removes all mcpx patterns", async () => {
+    await run(["allow", "github", "--json"], tmpDir);
+    await run(["allow", "--all-read", "--json"], tmpDir);
+
+    const { exitCode } = await run(["deny", "--all", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    const mcpxPatterns = (settings.permissions.allow as string[]).filter((p) =>
+      p.startsWith("Bash(mcpx "),
+    );
+    expect(mcpxPatterns.length).toBe(0);
+  });
+
+  test("--all-read removes read-only patterns", async () => {
+    await run(["allow", "--all-read", "--json"], tmpDir);
+    await run(["allow", "github", "--json"], tmpDir);
+
+    const { exitCode } = await run(["deny", "--all-read", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).not.toContain("Bash(mcpx search:*)");
+    // exec permission should still be there
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:github:*)");
+  });
+
+  test("preserves non-mcpx permissions", async () => {
+    const claudeDir = join(tmpDir, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(
+      join(claudeDir, "settings.local.json"),
+      JSON.stringify({
+        permissions: { allow: ["Bash(git:*)", "Bash(mcpx exec:github:*)"] },
+      }),
+    );
+
+    await run(["deny", "--all", "--json"], tmpDir);
+
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Bash(git:*)");
+    expect(settings.permissions.allow).not.toContain("Bash(mcpx exec:github:*)");
+  });
+
+  test("dry-run does not write", async () => {
+    await run(["allow", "github", "--json"], tmpDir);
+
+    const { exitCode, stdout } = await run(["deny", "github", "--dry-run", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.wouldRemove.length).toBeGreaterThan(0);
+
+    // Permission should still be there
+    const settings = await readSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Bash(mcpx exec:github:*)");
+  });
+
+  test("reports no changes when nothing matches", async () => {
+    await run(["allow", "github", "--json"], tmpDir);
+    const { exitCode, stdout } = await run(["deny", "linear", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.removed.length).toBe(0);
+  });
+});

--- a/test/commands/allow-deny.test.ts
+++ b/test/commands/allow-deny.test.ts
@@ -23,6 +23,12 @@ async function readSettings(dir: string, filename = "settings.local.json") {
   return JSON.parse(content);
 }
 
+async function readCursorSettings(dir: string, filename = "cli.json") {
+  const path = join(dir, ".cursor", filename);
+  const content = await readFile(path, "utf-8");
+  return JSON.parse(content);
+}
+
 describe("mcpx allow", () => {
   let tmpDir: string;
 
@@ -274,5 +280,251 @@ describe("mcpx deny", () => {
 
     const parsed = JSON.parse(stdout);
     expect(parsed.removed.length).toBe(0);
+  });
+});
+
+describe("mcpx allow --cursor", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mcpx-allow-cursor-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  test("allows a server", async () => {
+    const { exitCode } = await run(["allow", "github", "--cursor", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Shell(mcpx exec:github:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx allow:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx deny:*)");
+  });
+
+  test("allows specific tools", async () => {
+    const { exitCode } = await run(
+      ["allow", "github", "search_repositories", "get_file", "--cursor", "--json"],
+      tmpDir,
+    );
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Shell(mcpx exec:github:search_repositories:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx exec:github:get_file:*)");
+    expect(settings.permissions.allow).not.toContain("Shell(mcpx exec:github:*)");
+  });
+
+  test("allows --all", async () => {
+    const { exitCode } = await run(["allow", "--all", "--cursor", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Shell(mcpx exec:*)");
+  });
+
+  test("allows --all-read", async () => {
+    const { exitCode } = await run(["allow", "--all-read", "--cursor", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Shell(mcpx search:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx info:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx servers:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx ping:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx resource:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx prompt:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx task:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx index:*)");
+  });
+
+  test("deduplicates patterns on repeated runs", async () => {
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+
+    const settings = await readCursorSettings(tmpDir);
+    const count = settings.permissions.allow.filter(
+      (p: string) => p === "Shell(mcpx exec:github:*)",
+    ).length;
+    expect(count).toBe(1);
+  });
+
+  test("preserves existing non-mcpx permissions", async () => {
+    const cursorDir = join(tmpDir, ".cursor");
+    await mkdir(cursorDir, { recursive: true });
+    await writeFile(
+      join(cursorDir, "cli.json"),
+      JSON.stringify({
+        permissions: { allow: ["Shell(git)"] },
+      }),
+    );
+
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Shell(git)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx exec:github:*)");
+  });
+
+  test("dry-run does not write", async () => {
+    const { exitCode, stdout } = await run(
+      ["allow", "github", "--cursor", "--dry-run", "--json"],
+      tmpDir,
+    );
+    expect(exitCode).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.patterns).toContain("Shell(mcpx exec:github:*)");
+
+    // File should not exist
+    try {
+      await readCursorSettings(tmpDir);
+      throw new Error("expected file to not exist");
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message === "expected file to not exist") throw e;
+    }
+  });
+
+  test("--list shows Cursor permissions", async () => {
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+    const { exitCode, stdout } = await run(["allow", "--list", "--cursor", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    const local = parsed.find((r: { scope: string }) => r.scope === "local");
+    expect(local.patterns).toContain("Shell(mcpx exec:github:*)");
+  });
+
+  test("does not affect Claude settings", async () => {
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+
+    // Claude settings should not exist
+    try {
+      await readSettings(tmpDir);
+      throw new Error("expected Claude settings to not exist");
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message === "expected Claude settings to not exist") throw e;
+    }
+  });
+});
+
+describe("mcpx deny --cursor", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "mcpx-deny-cursor-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  test("removes a server permission", async () => {
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+
+    const settingsBefore = await readCursorSettings(tmpDir);
+    expect(settingsBefore.permissions.allow).toContain("Shell(mcpx exec:github:*)");
+
+    const { exitCode } = await run(["deny", "github", "--cursor", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).not.toContain("Shell(mcpx exec:github:*)");
+  });
+
+  test("removes specific tool permissions", async () => {
+    await run(["allow", "github", "search_repositories", "get_file", "--cursor", "--json"], tmpDir);
+
+    const { exitCode } = await run(
+      ["deny", "github", "search_repositories", "--cursor", "--json"],
+      tmpDir,
+    );
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).not.toContain(
+      "Shell(mcpx exec:github:search_repositories:*)",
+    );
+    expect(settings.permissions.allow).toContain("Shell(mcpx exec:github:get_file:*)");
+  });
+
+  test("removes server and all its tool patterns", async () => {
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+    await run(["allow", "github", "search_repositories", "--cursor", "--json"], tmpDir);
+
+    const { exitCode } = await run(["deny", "github", "--cursor", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    const githubPatterns = settings.permissions.allow.filter((p: string) =>
+      p.includes("mcpx exec:github"),
+    );
+    expect(githubPatterns.length).toBe(0);
+  });
+
+  test("--all removes all mcpx patterns", async () => {
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+    await run(["allow", "--all-read", "--cursor", "--json"], tmpDir);
+
+    const { exitCode } = await run(["deny", "--all", "--cursor", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    const mcpxPatterns = (settings.permissions.allow as string[]).filter((p) =>
+      p.startsWith("Shell(mcpx "),
+    );
+    expect(mcpxPatterns.length).toBe(0);
+  });
+
+  test("--all-read removes read-only patterns", async () => {
+    await run(["allow", "--all-read", "--cursor", "--json"], tmpDir);
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+
+    const { exitCode } = await run(["deny", "--all-read", "--cursor", "--json"], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).not.toContain("Shell(mcpx search:*)");
+    expect(settings.permissions.allow).toContain("Shell(mcpx exec:github:*)");
+  });
+
+  test("preserves non-mcpx permissions", async () => {
+    const cursorDir = join(tmpDir, ".cursor");
+    await mkdir(cursorDir, { recursive: true });
+    await writeFile(
+      join(cursorDir, "cli.json"),
+      JSON.stringify({
+        permissions: { allow: ["Shell(git)", "Shell(mcpx exec:github:*)"] },
+      }),
+    );
+
+    await run(["deny", "--all", "--cursor", "--json"], tmpDir);
+
+    const settings = await readCursorSettings(tmpDir);
+    expect(settings.permissions.allow).toContain("Shell(git)");
+    expect(settings.permissions.allow).not.toContain("Shell(mcpx exec:github:*)");
+  });
+
+  test("does not affect Claude settings", async () => {
+    // Set up Claude settings
+    const claudeDir = join(tmpDir, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(
+      join(claudeDir, "settings.local.json"),
+      JSON.stringify({
+        permissions: { allow: ["Bash(mcpx exec:github:*)"] },
+      }),
+    );
+
+    // Set up Cursor settings
+    await run(["allow", "github", "--cursor", "--json"], tmpDir);
+    await run(["deny", "--all", "--cursor", "--json"], tmpDir);
+
+    // Claude settings should be untouched
+    const claudeSettings = await readSettings(tmpDir);
+    expect(claudeSettings.permissions.allow).toContain("Bash(mcpx exec:github:*)");
   });
 });


### PR DESCRIPTION
## Summary

- New `mcpx allow` command to add fine-grained permission rules (per-server, per-tool, read-only, or all)
- New `mcpx deny` command to remove permission rules
- **Supports both Claude Code and Cursor** — use `--cursor` flag to target Cursor settings
  - Claude Code: `Bash()` patterns → `.claude/settings.local.json`
  - Cursor: `Shell()` patterns → `.cursor/cli.json`, `~/.cursor/cli-config.json`
- Both support `--local`/`--project`/`--global` scope, `--dry-run`, and `--list` (allow only)
- Core logic in `src/lib/client-settings.ts` (generalized from `claude-settings.ts`), 35 tests in `test/commands/allow-deny.test.ts`
- Skill file and Cursor rules updated with self-authorize workflow
- README updated with commands table entries and new "Permissions (Claude Code & Cursor)" section
- Version bumped to 0.16.1

Closes https://github.com/evantahler/mcpx/issues/52

## Test plan

- [x] All 19 existing Claude Code tests pass (backward compatible)
- [x] 16 new Cursor tests pass (allow + deny, patterns, dedup, isolation from Claude settings)
- [x] Manual dry-run verified for both `--cursor` and default Claude targets
- [x] `bun format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)