### PR TITLE
Add --format flag for text and markdown output modes

### DIFF
--- a/.claude/skills/mcpx.md
+++ b/.claude/skills/mcpx.md
@@ -29,7 +29,7 @@ mcpx exec <server> <tool> '<json args>'
 mcpx exec <server> <tool> -f params.json
 ```
 
-Output is JSON when piped. Use `--json` to force JSON output in any context — prefer this when you need to parse results programmatically.
+Output is JSON by default. Use `--json` to force JSON output in any context — prefer this when you need to parse results programmatically. Use `--format text` to extract just the text content (stripping the MCP protocol wrapper), or `--format markdown` for rich terminal rendering.
 
 ## Rules
 
@@ -38,6 +38,8 @@ Output is JSON when piped. Use `--json` to force JSON output in any context — 
 - Use `mcpx search -k` for exact name matching
 - Pipe results through `jq` when you need to extract specific fields
 - Use `--json` when parsing output programmatically (automatic when piped, but explicit is safer)
+- Use `--format text` to extract plain text from tool results (strips MCP protocol wrapper)
+- Use `--format markdown` for rich terminal-rendered output with colors and formatting
 - Use `-v` for verbose debugging (HTTP details + JSON-RPC protocol messages) if an exec fails unexpectedly
 - Use `-l debug` to see all server log messages, or `-l error` for errors only
 
@@ -149,15 +151,16 @@ mcpx deauth <server>           # remove stored auth
 
 ## Global flags
 
-| Flag                      | Purpose                                                  |
-| ------------------------- | -------------------------------------------------------- |
-| `-j, --json`              | Force JSON output (default when piped)                   |
-| `-v, --verbose`           | Show HTTP details and JSON-RPC protocol messages         |
-| `-d, --with-descriptions` | Include tool descriptions in list output                 |
-| `-c, --config <path>`     | Specify config file location                             |
-| `-N, --no-interactive`    | Decline server elicitation requests (for scripted usage) |
-| `-S, --show-secrets`      | Show full auth tokens in verbose output (unmasked)       |
-| `-l, --log-level <level>` | Minimum server log level to display (default: `warning`) |
+| Flag                        | Purpose                                                  |
+| --------------------------- | -------------------------------------------------------- |
+| `-j, --json`                | Force JSON output (default when piped)                   |
+| `-F, --format <format>`     | Output format: `json`, `text`, or `markdown`             |
+| `-v, --verbose`             | Show HTTP details and JSON-RPC protocol messages         |
+| `-d, --with-descriptions`   | Include tool descriptions in list output                 |
+| `-c, --config <path>`       | Specify config file location                             |
+| `-N, --no-interactive`      | Decline server elicitation requests (for scripted usage) |
+| `-S, --show-secrets`        | Show full auth tokens in verbose output (unmasked)       |
+| `-l, --log-level <level>`   | Minimum server log level to display (default: `warning`) |
 
 ## `add` options
 

--- a/.cursor/rules/mcpx.mdc
+++ b/.cursor/rules/mcpx.mdc
@@ -29,12 +29,17 @@ mcpx exec <server> <tool> '<json args>'
 mcpx exec <server> <tool> -f params.json
 ```
 
+Output is JSON by default. Use `--json` to force JSON output in any context — prefer this when you need to parse results programmatically. Use `--format text` to extract just the text content (stripping the MCP protocol wrapper), or `--format markdown` for rich terminal rendering.
+
 ## Rules
 
 - Always search before executing — don't assume tool names exist
 - Always inspect the schema before executing — validate you have the right arguments
 - Use `mcpx search -k` for exact name matching
 - Pipe results through `jq` when you need to extract specific fields
+- Use `--json` when parsing output programmatically (automatic when piped, but explicit is safer)
+- Use `--format text` to extract plain text from tool results (strips MCP protocol wrapper)
+- Use `--format markdown` for rich terminal-rendered output with colors and formatting
 - Use `-v` for verbose debugging (HTTP details + JSON-RPC protocol messages) if an exec fails unexpectedly
 - Use `-l debug` to see all server log messages, or `-l error` for errors only
 
@@ -163,3 +168,16 @@ mcpx deauth <server>      # remove stored auth
 | `mcpx task get <server> <taskId>`    | Get task status                 |
 | `mcpx task result <server> <taskId>` | Retrieve completed task result  |
 | `mcpx task cancel <server> <taskId>` | Cancel a running task           |
+
+## Global flags
+
+| Flag                        | Purpose                                                  |
+| --------------------------- | -------------------------------------------------------- |
+| `-j, --json`                | Force JSON output (default when piped)                   |
+| `-F, --format <format>`     | Output format: `json`, `text`, or `markdown`             |
+| `-v, --verbose`             | Show HTTP details and JSON-RPC protocol messages         |
+| `-d, --with-descriptions`   | Include tool descriptions in list output                 |
+| `-c, --config <path>`       | Specify config file location                             |
+| `-N, --no-interactive`      | Decline server elicitation requests (for scripted usage) |
+| `-S, --show-secrets`        | Show full auth tokens in verbose output (unmasked)       |
+| `-l, --log-level <level>`   | Minimum server log level to display (default: `warning`) |

--- a/.cursor/rules/mcpx.mdc
+++ b/.cursor/rules/mcpx.mdc
@@ -63,16 +63,22 @@ mcpx exec github search_repositories '{"query":"mcp"}' \
 # Read args from stdin
 echo '{"path":"./README.md"}' | mcpx exec filesystem read_file
 
-# Pipe from a file
-cat params.json | mcpx exec server tool
-
 # Read args from a file with --file flag
 mcpx exec filesystem read_file -f params.json
 ```
 
-## 4. Long-running tools (Tasks)
+## Troubleshooting
 
-Some tools support async execution via MCP Tasks. mcpx auto-detects this and uses task-augmented execution when available.
+- **"Not authenticated" / 401 error** → Run `mcpx auth <server>` to start the OAuth flow
+- **Exec timeout** → Use `-v` to see where it stalls; set `MCP_TIMEOUT=<seconds>` to increase the timeout (default: 1800)
+- **Search returns no results** → Try `mcpx search -k "*keyword*"` for glob matching, or `mcpx index` to rebuild the search index
+- **Missing or stale tools** → Run `mcpx index` to rebuild; any command that connects to a server also auto-updates the index
+- **Server won't connect** → Run `mcpx ping <server>` to check connectivity; use `-v` for protocol-level details
+- **Auth token expired** → Run `mcpx auth <server> -r` to force a token refresh
+
+## Long-running tools (Tasks)
+
+Some tools support async execution via MCP Tasks. mcpx auto-detects this.
 
 ```bash
 # Default: waits for the task to complete, showing progress
@@ -81,93 +87,67 @@ mcpx exec my-server long_running_tool '{"input": "data"}'
 # Return immediately with a task handle (for scripting/polling)
 mcpx exec my-server long_running_tool '{"input": "data"}' --no-wait
 
-# Check task status
+# Check task status / retrieve result / cancel
 mcpx task get my-server <taskId>
-
-# Retrieve the result once complete
 mcpx task result my-server <taskId>
-
-# List all tasks on a server
-mcpx task list my-server
-
-# Cancel a running task
 mcpx task cancel my-server <taskId>
+mcpx task list my-server
 ```
 
-For tools that don't support tasks, `exec` works exactly as before.
+## Elicitation (Server-Requested Input)
 
-## 5. Elicitation (Server-Requested Input)
-
-Some servers request user input mid-operation (e.g., confirmations, auth flows). mcpx handles this automatically:
-
-```bash
-# Interactive — prompts appear in the terminal
-mcpx exec my-server deploy_tool '{"target": "staging"}'
-# Server requests input: Confirm deployment
-#   *Confirm [y/n]: y
-
-# Non-interactive — decline all elicitation (for scripts/CI)
-mcpx exec my-server deploy_tool '{"target": "staging"}' --no-interactive
-
-# JSON mode — read/write elicitation as JSON via stdin/stdout
-echo '{"action":"accept","content":{"confirm":true}}' | \
-  mcpx exec my-server deploy_tool '{"target": "staging"}' --json
-```
+Some servers request user input mid-operation. mcpx handles this automatically in interactive mode. Use `-N` / `--no-interactive` to decline all elicitation (for scripts/CI), or `--json` to handle elicitation programmatically via stdin/stdout.
 
 ## Authentication
 
-Some HTTP servers require OAuth. If you see an "Not authenticated" error:
-
 ```bash
-mcpx auth <server>        # authenticate via browser
-mcpx auth <server> -s     # check token status and TTL
-mcpx auth <server> -r     # force token refresh
-mcpx deauth <server>      # remove stored auth
+mcpx auth <server>             # authenticate via browser
+mcpx auth <server> -s          # check token status and TTL
+mcpx auth <server> -r          # force token refresh
+mcpx auth <server> --no-index  # authenticate without rebuilding search index
+mcpx deauth <server>           # remove stored auth
 ```
 
 ## Available commands
 
 | Command                                | Purpose                           |
 | -------------------------------------- | --------------------------------- |
-| `mcpx`                               | List all servers and tools        |
-| `mcpx servers`                       | List servers (name, type, detail) |
-| `mcpx -d`                            | List with descriptions            |
-| `mcpx info <server>`                 | Server overview (version, capabilities, tools) |
-| `mcpx info <server> <tool>`          | Show tool schema                  |
-| `mcpx exec <server>`                 | List tools for a server           |
-| `mcpx exec <server> <tool> '<json>'` | Execute a tool                    |
-| `mcpx exec <server> <tool> -f file`  | Execute with args from file       |
-| `mcpx search "<query>"`              | Search tools (keyword + semantic) |
-| `mcpx search -k "<pattern>"`         | Keyword/glob search only          |
-| `mcpx search -q "<query>"`           | Semantic search only              |
-| `mcpx search -n <number> "<query>"`  | Limit number of results (default: 10) |
-| `mcpx index`                         | Build/rebuild search index        |
-| `mcpx index -i`                      | Show index status                 |
-| `mcpx auth <server>`                 | Authenticate with OAuth           |
-| `mcpx auth <server> -s`              | Check token status and TTL        |
+| `mcpx`                                | List all servers and tools        |
+| `mcpx servers`                        | List servers (name, type, detail) |
+| `mcpx -d`                             | List with descriptions            |
+| `mcpx info <server>`                  | Server overview (version, capabilities, tools) |
+| `mcpx info <server> <tool>`           | Show tool schema                  |
+| `mcpx exec <server>`                  | List tools for a server           |
+| `mcpx exec <server> <tool> '<json>'`  | Execute a tool                    |
+| `mcpx exec <server> <tool> -f file`   | Execute with args from file       |
+| `mcpx search "<query>"`               | Search tools (keyword + semantic) |
+| `mcpx search -k "<pattern>"`          | Keyword/glob search only          |
+| `mcpx search -q "<query>"`            | Semantic search only              |
+| `mcpx search -n <number> "<query>"`   | Limit number of results (default: 10) |
+| `mcpx index`                          | Build/rebuild search index        |
+| `mcpx index -i`                       | Show index status                 |
+| `mcpx auth <server>`                  | Authenticate with OAuth           |
+| `mcpx auth <server> -s`               | Check token status and TTL        |
 | `mcpx auth <server> -r`              | Force token refresh               |
-| `mcpx deauth <server>`               | Remove stored authentication      |
-| `mcpx ping`                          | Check connectivity to all servers |
-| `mcpx ping <server> [server2...]`    | Check specific server(s)          |
-| `mcpx add <name> --command <cmd>`    | Add a stdio MCP server            |
-| `mcpx add <name> --url <url>`        | Add an HTTP MCP server            |
-| `mcpx add <name> --url <url> --transport sse` | Add a legacy SSE server  |
-| `mcpx remove <name>`                 | Remove an MCP server              |
-| `mcpx skill install --claude`        | Install mcpx skill for Claude   |
-| `mcpx skill install --cursor`        | Install mcpx rule for Cursor    |
-| `mcpx resource`                     | List all resources across servers |
-| `mcpx resource <server>`            | List resources for a server       |
-| `mcpx resource <server> <uri>`      | Read a specific resource          |
-| `mcpx prompt`                       | List all prompts across servers   |
-| `mcpx prompt <server>`              | List prompts for a server         |
-| `mcpx prompt <server> <name> '<json>'` | Get a specific prompt          |
-| `mcpx exec <server> <tool> --no-wait` | Execute as async task, return handle |
-| `mcpx exec <server> <tool> --ttl <ms>` | Set task TTL (default: 60000) |
-| `mcpx -N exec <server> <tool> ...`  | Decline elicitation (non-interactive) |
-| `mcpx task list <server>`            | List tasks on a server          |
-| `mcpx task get <server> <taskId>`    | Get task status                 |
-| `mcpx task result <server> <taskId>` | Retrieve completed task result  |
-| `mcpx task cancel <server> <taskId>` | Cancel a running task           |
+| `mcpx auth <server> --no-index`       | Authenticate without rebuilding index |
+| `mcpx deauth <server>`                | Remove stored authentication      |
+| `mcpx ping`                           | Check connectivity to all servers |
+| `mcpx ping <server> [server2...]`     | Check specific server(s)          |
+| `mcpx add <name> --command <cmd>`     | Add a stdio MCP server            |
+| `mcpx add <name> --url <url>`         | Add an HTTP MCP server            |
+| `mcpx remove <name>`                  | Remove an MCP server              |
+| `mcpx skill install --claude`         | Install mcpx skill for Claude     |
+| `mcpx skill install --cursor`         | Install mcpx rule for Cursor      |
+| `mcpx resource`                       | List all resources across servers |
+| `mcpx resource <server>`              | List resources for a server       |
+| `mcpx resource <server> <uri>`        | Read a specific resource          |
+| `mcpx prompt`                         | List all prompts across servers   |
+| `mcpx prompt <server>`                | List prompts for a server         |
+| `mcpx prompt <server> <name> '<json>'` | Get a specific prompt            |
+| `mcpx task list <server>`             | List tasks on a server            |
+| `mcpx task get <server> <taskId>`     | Get task status                   |
+| `mcpx task result <server> <taskId>`  | Retrieve completed task result    |
+| `mcpx task cancel <server> <taskId>`  | Cancel a running task             |
 
 ## Global flags
 
@@ -181,3 +161,48 @@ mcpx deauth <server>      # remove stored auth
 | `-N, --no-interactive`      | Decline server elicitation requests (for scripted usage) |
 | `-S, --show-secrets`        | Show full auth tokens in verbose output (unmasked)       |
 | `-l, --log-level <level>`   | Minimum server log level to display (default: `warning`) |
+
+## `add` options
+
+| Flag                       | Purpose                                |
+| -------------------------- | -------------------------------------- |
+| `--command <cmd>`          | Command to run (stdio server)          |
+| `--args <a1,a2,...>`       | Comma-separated arguments              |
+| `--env <KEY=VAL,...>`      | Comma-separated environment variables  |
+| `--cwd <dir>`              | Working directory for the command      |
+| `--url <url>`              | Server URL (HTTP server)               |
+| `--header <Key:Value>`     | HTTP header (repeatable)               |
+| `--transport <type>`       | Transport: `sse` or `streamable-http`  |
+| `--allowed-tools <t1,t2>`  | Comma-separated allowed tool patterns  |
+| `--disabled-tools <t1,t2>` | Comma-separated disabled tool patterns |
+| `-f, --force`              | Overwrite if server already exists     |
+| `--no-auth`                | Skip automatic OAuth after adding      |
+| `--no-index`               | Skip rebuilding the search index       |
+
+## `remove` options
+
+| Flag          | Purpose                                          |
+| ------------- | ------------------------------------------------ |
+| `--keep-auth` | Don't remove stored auth credentials             |
+| `--dry-run`   | Show what would be removed without changing files |
+
+## `skill install` options
+
+| Flag        | Purpose                                    |
+| ----------- | ------------------------------------------ |
+| `--claude`  | Install skill for Claude Code              |
+| `--cursor`  | Install rule for Cursor                    |
+| `--global`  | Install to global location (`~/`)          |
+| `--project` | Install to project location (default)      |
+| `-f, --force` | Overwrite if file already exists         |
+
+## Environment variables
+
+| Variable          | Purpose                     | Default    |
+| ----------------- | --------------------------- | ---------- |
+| `MCP_CONFIG_PATH` | Config directory path       | `~/.mcpx/` |
+| `MCP_TIMEOUT`     | Request timeout (seconds)   | `1800`     |
+| `MCP_CONCURRENCY` | Parallel server connections | `5`        |
+| `MCP_MAX_RETRIES` | Retry attempts              | `3`        |
+| `MCP_STRICT_ENV`  | Error on missing `${VAR}`   | `true`     |
+| `MCP_DEBUG`       | Enable debug output         | `false`    |

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ mcpx search -n 5 "manage pull requests"
 | `-v, --verbose`           | Show HTTP details and JSON-RPC protocol messages         |
 | `-S, --show-secrets`      | Show full auth tokens in verbose output (unmasked)       |
 | `-j, --json`              | Force JSON output (default when piped)                   |
+| `-F, --format <format>`   | Output format: `json`, `text`, or `markdown`             |
 | `-N, --no-interactive`    | Decline server elicitation requests (for scripted usage) |
 | `-l, --log-level <level>` | Minimum server log level to display (default: `warning`) |
 
@@ -495,7 +496,36 @@ mcpx info github | jq '.tools[].name'
 mcpx info github --json
 ```
 
-Tool results are always JSON, designed for chaining:
+### Output Formats (`--format`)
+
+Tool results (`exec`, `task result`) support three output formats via the global `--format` / `-F` flag:
+
+| Format     | Description                                                             |
+| ---------- | ----------------------------------------------------------------------- |
+| `json`     | Full MCP protocol response as JSON (default)                            |
+| `text`     | Extract text from content blocks, strip protocol wrapper                |
+| `markdown` | Extract text and render with rich terminal formatting (colors, borders) |
+
+```bash
+# Default JSON output — full MCP response with content array
+mcpx exec github search_repositories '{"query":"mcp"}'
+
+# Text — just the content, no protocol wrapper
+mcpx exec github search_repositories '{"query":"mcp"}' --format text
+
+# Markdown — rich terminal rendering with colors and formatting
+mcpx exec github search_repositories '{"query":"mcp"}' -F markdown
+```
+
+The `text` format extracts text from MCP content blocks and strips the protocol wrapper. If the text contains JSON, it's pretty-printed. Non-text content (images, resources) gets descriptive placeholders.
+
+The `markdown` format extracts text the same way, then renders it through Bun's built-in markdown parser with ANSI styling — headings, bold/italic, code blocks with borders, colored links, and bullet lists.
+
+For other commands (`list`, `info`, `search`), `--format json` forces JSON output and `--format text`/`--format markdown` use the existing human-friendly formatting.
+
+### Chaining tool results
+
+Tool results are JSON by default, designed for chaining:
 
 ```bash
 # Search repos and read the first result

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.15.9",
+  "version": "0.16.0",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ program
   .option("-c, --config <path>", "config directory path")
   .option("-d, --with-descriptions", "include tool descriptions in output")
   .option("-j, --json", "force JSON output")
+  .option("-F, --format <format>", "output format (json, text, markdown)")
   .option("-v, --verbose", "show HTTP details and JSON-RPC protocol messages")
   .option("-S, --show-secrets", "show full auth tokens in verbose output")
   .option("-N, --no-interactive", "decline server elicitation requests")
@@ -56,7 +57,14 @@ const cliArgs = process.argv.slice(2);
 let firstCommand: string | undefined;
 for (let i = 0; i < cliArgs.length; i++) {
   const a = cliArgs[i];
-  if (a === "-c" || a === "--config" || a === "-l" || a === "--log-level") {
+  if (
+    a === "-c" ||
+    a === "--config" ||
+    a === "-l" ||
+    a === "--log-level" ||
+    a === "-F" ||
+    a === "--format"
+  ) {
     i++; // skip the option's value argument
     continue;
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander";
 import { loadConfig, type LoadConfigOptions } from "./config/loader.ts";
 import { ServerManager } from "./client/manager.ts";
 import type { Config } from "./config/schemas.ts";
-import type { FormatOptions } from "./output/formatter.ts";
+import { type FormatOptions, type OutputFormat, VALID_FORMATS } from "./output/formatter.ts";
 import { logger } from "./output/logger.ts";
 import { ENV, DEFAULTS } from "./constants.ts";
 
@@ -35,6 +35,13 @@ export async function getContext(program: Command): Promise<AppContext> {
   // Commander's --no-interactive sets opts.interactive = false (default true)
   const noInteractive = opts.interactive === false;
 
+  const formatFlag = opts.format as string | undefined;
+  if (formatFlag && !VALID_FORMATS.includes(formatFlag as OutputFormat)) {
+    console.error(`error: Invalid format "${formatFlag}". Use: ${VALID_FORMATS.join(", ")}`);
+    process.exit(1);
+  }
+  const format = formatFlag as OutputFormat | undefined;
+
   const manager = new ServerManager({
     servers: config.servers,
     configDir: config.configDir,
@@ -55,6 +62,7 @@ export async function getContext(program: Command): Promise<AppContext> {
     verbose,
     showSecrets,
     logLevel,
+    format,
   };
 
   logger.configure(formatOptions);

--- a/src/output/format-output.ts
+++ b/src/output/format-output.ts
@@ -3,14 +3,24 @@ import { isInteractive } from "./formatter.ts";
 
 /**
  * Format output with automatic JSON/interactive branching.
- * In non-interactive mode, returns JSON.stringify of jsonData.
- * In interactive mode, calls interactiveFn() for formatted output.
+ * When --format is explicitly set, it takes precedence:
+ *   json → JSON.stringify of jsonData
+ *   text or markdown → interactiveFn() (already well-formatted for non-exec commands)
+ * Otherwise falls back to the existing auto-detection:
+ *   non-interactive → JSON, interactive → formatted text.
  */
 export function formatOutput(
   jsonData: unknown,
   interactiveFn: () => string,
   options: FormatOptions,
 ): string {
+  if (options.format) {
+    if (options.format === "json") {
+      return JSON.stringify(jsonData, null, 2);
+    }
+    // text and markdown use the interactive formatter for non-exec commands
+    return interactiveFn();
+  }
   if (!isInteractive(options)) {
     return JSON.stringify(jsonData, null, 2);
   }

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -423,58 +423,9 @@ function formatCallResultAsMarkdown(result: unknown): string {
   return renderMarkdownToAnsi(text);
 }
 
-/** Render a markdown string to ANSI-styled terminal output using Bun's built-in parser */
+/** Render a markdown string to ANSI-styled terminal output using Bun's built-in renderer */
 export function renderMarkdownToAnsi(input: string): string {
-  const cols = process.stdout.columns ?? 80;
-  const rule = dim("─".repeat(Math.min(cols, 80)));
-
-  return Bun.markdown.render(input, {
-    heading: (children: string, opts: { level: number }) => {
-      if (opts.level === 1) {
-        return `\n${rule}\n${bold(children)}\n${rule}\n\n`;
-      }
-      if (opts.level === 2) {
-        return `\n${bold(children)}\n${dim("─".repeat(children.length))}\n\n`;
-      }
-      return `\n${bold(children)}\n\n`;
-    },
-    strong: (children: string) => bold(children),
-    emphasis: (children: string) => ansis.italic(children),
-    paragraph: (children: string) => children + "\n\n",
-    codespan: (code: string) => cyan(code),
-    code: (code: string, opts: { language?: string }) => {
-      const lang = opts.language ? dim(` ${opts.language}`) : "";
-      const border = dim("│ ");
-      const lines = code.replace(/\n$/, "").split("\n");
-      const formatted = lines.map((l: string) => border + l).join("\n");
-      return `${dim("┌──")}${lang}\n${formatted}\n${dim("└──")}\n\n`;
-    },
-    blockquote: (children: string) => {
-      const lines = children.replace(/\n$/, "").split("\n");
-      return lines.map((l: string) => `${dim("│")} ${l}`).join("\n") + "\n\n";
-    },
-    list: (children: string) => children + "\n",
-    listItem: (children: string, opts: { ordered: boolean; index: number; depth: number }) => {
-      const indent = "  ".repeat(opts.depth);
-      const bullet = opts.ordered ? `${opts.index + 1}.` : dim("•");
-      return `${indent}${bullet} ${children.trim()}\n`;
-    },
-    hr: () => rule + "\n\n",
-    link: (children: string, opts: { href: string }) => {
-      if (children === opts.href) return cyan(opts.href);
-      return `${children} ${dim("(")}${cyan(opts.href)}${dim(")")}`;
-    },
-    image: (alt: string, opts: { src: string }) =>
-      `${dim("[image:")} ${alt || opts.src}${dim("]")}\n`,
-    table: (children: string) => children + "\n",
-    thead: (children: string) => children,
-    tbody: (children: string) => children,
-    tr: (children: string) => children + "\n",
-    th: (children: string) => bold(children) + "\t",
-    td: (children: string) => children + "\t",
-    strikethrough: (children: string) => ansis.strikethrough(children),
-    text: (text: string) => text,
-  });
+  return Bun.markdown.ansi(input);
 }
 
 /** Recursively parse JSON strings inside MCP content blocks */

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -6,12 +6,17 @@ import type { SearchResult } from "../search/index.ts";
 import { formatOutput } from "./format-output.ts";
 import { formatTable } from "./format-table.ts";
 
+export type OutputFormat = "json" | "text" | "markdown";
+
+export const VALID_FORMATS: OutputFormat[] = ["json", "text", "markdown"];
+
 export interface FormatOptions {
   json?: boolean;
   withDescriptions?: boolean;
   verbose?: boolean;
   showSecrets?: boolean;
   logLevel?: string;
+  format?: OutputFormat;
 }
 
 export interface UnifiedItem {
@@ -345,9 +350,131 @@ function exampleValue(name: string, prop: Record<string, unknown>): unknown {
   }
 }
 
-/** Format a tool call result */
-export function formatCallResult(result: unknown, _options: FormatOptions): string {
-  return JSON.stringify(parseNestedJson(result), null, 2);
+/** Format a tool call result, dispatching on the --format option */
+export function formatCallResult(result: unknown, options: FormatOptions): string {
+  const format = options.format ?? "json";
+
+  switch (format) {
+    case "text":
+      return formatCallResultAsText(result);
+    case "markdown":
+      return formatCallResultAsMarkdown(result);
+    case "json":
+    default:
+      return JSON.stringify(parseNestedJson(result), null, 2);
+  }
+}
+
+/** Extract human-readable text from an MCP tool call result */
+function formatCallResultAsText(result: unknown): string {
+  const r = result as {
+    content?: Array<{
+      type: string;
+      text?: string;
+      data?: string;
+      mimeType?: string;
+      uri?: string;
+    }>;
+    isError?: boolean;
+  };
+
+  if (!r.content || !Array.isArray(r.content) || r.content.length === 0) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  const parts: string[] = [];
+
+  for (const block of r.content) {
+    switch (block.type) {
+      case "text":
+        if (block.text !== undefined) {
+          try {
+            const parsed = JSON.parse(block.text);
+            parts.push(JSON.stringify(parsed, null, 2));
+          } catch {
+            parts.push(block.text);
+          }
+        }
+        break;
+      case "image":
+        parts.push(
+          `[image: ${block.mimeType ?? "unknown type"}, ${block.data ? Math.ceil((block.data.length * 3) / 4) : 0} bytes]`,
+        );
+        break;
+      case "resource":
+        parts.push(`[resource: ${block.uri ?? "unknown"}]`);
+        break;
+      default:
+        parts.push(`[${block.type}]`);
+        break;
+    }
+  }
+
+  let output = parts.join("\n");
+  if (r.isError) {
+    output = `error: ${output}`;
+  }
+  return output;
+}
+
+/** Render an MCP tool call result as styled markdown for terminal output */
+function formatCallResultAsMarkdown(result: unknown): string {
+  const text = formatCallResultAsText(result);
+  return renderMarkdownToAnsi(text);
+}
+
+/** Render a markdown string to ANSI-styled terminal output using Bun's built-in parser */
+export function renderMarkdownToAnsi(input: string): string {
+  const cols = process.stdout.columns ?? 80;
+  const rule = dim("─".repeat(Math.min(cols, 80)));
+
+  return Bun.markdown.render(input, {
+    heading: (children: string, opts: { level: number }) => {
+      if (opts.level === 1) {
+        return `\n${rule}\n${bold(children)}\n${rule}\n\n`;
+      }
+      if (opts.level === 2) {
+        return `\n${bold(children)}\n${dim("─".repeat(children.length))}\n\n`;
+      }
+      return `\n${bold(children)}\n\n`;
+    },
+    strong: (children: string) => bold(children),
+    emphasis: (children: string) => ansis.italic(children),
+    paragraph: (children: string) => children + "\n\n",
+    codespan: (code: string) => cyan(code),
+    code: (code: string, opts: { language?: string }) => {
+      const lang = opts.language ? dim(` ${opts.language}`) : "";
+      const border = dim("│ ");
+      const lines = code.replace(/\n$/, "").split("\n");
+      const formatted = lines.map((l: string) => border + l).join("\n");
+      return `${dim("┌──")}${lang}\n${formatted}\n${dim("└──")}\n\n`;
+    },
+    blockquote: (children: string) => {
+      const lines = children.replace(/\n$/, "").split("\n");
+      return lines.map((l: string) => `${dim("│")} ${l}`).join("\n") + "\n\n";
+    },
+    list: (children: string) => children + "\n",
+    listItem: (children: string, opts: { ordered: boolean; index: number; depth: number }) => {
+      const indent = "  ".repeat(opts.depth);
+      const bullet = opts.ordered ? `${opts.index + 1}.` : dim("•");
+      return `${indent}${bullet} ${children.trim()}\n`;
+    },
+    hr: () => rule + "\n\n",
+    link: (children: string, opts: { href: string }) => {
+      if (children === opts.href) return cyan(opts.href);
+      return `${children} ${dim("(")}${cyan(opts.href)}${dim(")")}`;
+    },
+    image: (alt: string, opts: { src: string }) =>
+      `${dim("[image:")} ${alt || opts.src}${dim("]")}\n`,
+    table: (children: string) => children + "\n",
+    thead: (children: string) => children,
+    tbody: (children: string) => children,
+    tr: (children: string) => children + "\n",
+    th: (children: string) => bold(children) + "\t",
+    td: (children: string) => children + "\t",
+    strikethrough: (children: string) => ansis.strikethrough(children),
+    text: (text: string) => text,
+  });
 }
 
 /** Recursively parse JSON strings inside MCP content blocks */

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -6,9 +6,9 @@ import type { SearchResult } from "../search/index.ts";
 import { formatOutput } from "./format-output.ts";
 import { formatTable } from "./format-table.ts";
 
-export type OutputFormat = "json" | "text" | "markdown";
+export const VALID_FORMATS = ["json", "text", "markdown"] as const;
 
-export const VALID_FORMATS: OutputFormat[] = ["json", "text", "markdown"];
+export type OutputFormat = (typeof VALID_FORMATS)[number];
 
 export interface FormatOptions {
   json?: boolean;

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -419,8 +419,127 @@ function formatCallResultAsText(result: unknown): string {
 
 /** Render an MCP tool call result as styled markdown for terminal output */
 function formatCallResultAsMarkdown(result: unknown): string {
-  const text = formatCallResultAsText(result);
-  return renderMarkdownToAnsi(text);
+  const r = result as {
+    content?: Array<{
+      type: string;
+      text?: string;
+      data?: string;
+      mimeType?: string;
+      uri?: string;
+    }>;
+    isError?: boolean;
+  };
+
+  if (!r.content || !Array.isArray(r.content) || r.content.length === 0) {
+    return renderMarkdownToAnsi(jsonToMarkdown(result));
+  }
+
+  const parts: string[] = [];
+
+  for (const block of r.content) {
+    switch (block.type) {
+      case "text":
+        if (block.text !== undefined) {
+          try {
+            const parsed = JSON.parse(block.text);
+            parts.push(jsonToMarkdown(parsed));
+          } catch {
+            // Plain text / already markdown — pass through as-is
+            parts.push(block.text);
+          }
+        }
+        break;
+      case "image":
+        parts.push(
+          `[image: ${block.mimeType ?? "unknown type"}, ${block.data ? Math.ceil((block.data.length * 3) / 4) : 0} bytes]`,
+        );
+        break;
+      case "resource":
+        parts.push(`[resource: ${block.uri ?? "unknown"}]`);
+        break;
+      default:
+        parts.push(`[${block.type}]`);
+        break;
+    }
+  }
+
+  let output = parts.join("\n\n");
+  if (r.isError) {
+    output = `**error:** ${output}`;
+  }
+  return renderMarkdownToAnsi(output);
+}
+
+/** Convert a key name like "display_name" to "Display Name" */
+function humanizeKey(key: string): string {
+  return key
+    .replace(/[_-]/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Check if a value is a plain primitive (string, number, boolean, null) */
+function isPrimitive(value: unknown): value is string | number | boolean | null {
+  return value === null || typeof value !== "object";
+}
+
+/**
+ * Convert a JSON value into a readable markdown document.
+ * Object keys become headings at their nesting depth (depth 1 = #, depth 2 = ##, etc.).
+ * Arrays of primitives become bullet lists. Arrays of objects get numbered sub-sections.
+ * Headings are capped at depth 6 (######); deeper nesting uses **bold** labels instead.
+ */
+export function jsonToMarkdown(value: unknown, depth: number = 1): string {
+  if (isPrimitive(value)) {
+    return String(value ?? "null");
+  }
+
+  if (Array.isArray(value)) {
+    // Array of all primitives → bullet list
+    if (value.every(isPrimitive)) {
+      return value.map((v) => `- ${String(v ?? "null")}`).join("\n");
+    }
+    // Array of objects → numbered sub-sections
+    return value
+      .map((item, i) => {
+        if (isPrimitive(item)) {
+          return `- ${String(item ?? "null")}`;
+        }
+        const label = depth <= 6 ? `${"#".repeat(depth)} ${i + 1}` : `**${i + 1}**`;
+        return `${label}\n\n${jsonToMarkdown(item, depth + 1)}`;
+      })
+      .join("\n\n");
+  }
+
+  // Object → each key becomes a heading
+  const entries = Object.entries(value as Record<string, unknown>);
+  const lines: string[] = [];
+
+  for (const [key, val] of entries) {
+    const heading = humanizeKey(key);
+
+    if (isPrimitive(val)) {
+      if (depth <= 6) {
+        lines.push(`${"#".repeat(depth)} ${heading}\n\n${String(val ?? "null")}`);
+      } else {
+        lines.push(`**${heading}:** ${String(val ?? "null")}`);
+      }
+    } else if (Array.isArray(val) && val.every(isPrimitive)) {
+      // Array of primitives: heading then bullet list
+      const list = val.map((v) => `- ${String(v ?? "null")}`).join("\n");
+      if (depth <= 6) {
+        lines.push(`${"#".repeat(depth)} ${heading}\n\n${list}`);
+      } else {
+        lines.push(`**${heading}:**\n${list}`);
+      }
+    } else {
+      // Nested object or array of objects
+      const label = depth <= 6 ? `${"#".repeat(depth)} ${heading}` : `**${heading}**`;
+      lines.push(`${label}\n\n${jsonToMarkdown(val, depth + 1)}`);
+    }
+  }
+
+  return lines.join("\n\n");
 }
 
 /** Render a markdown string to ANSI-styled terminal output using Bun's built-in renderer */

--- a/test/commands/exec.test.ts
+++ b/test/commands/exec.test.ts
@@ -135,6 +135,66 @@ describe("mcpx exec", () => {
     expect(stderr).toContain("File not found");
   });
 
+  test("--format text extracts text content from result", async () => {
+    const proc = run("--format", "text", "exec", "mock", "echo", '{"message": "hello world"}');
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("hello world");
+  });
+
+  test("--format text pretty-prints JSON text content", async () => {
+    const proc = run(
+      "--format",
+      "text",
+      "exec",
+      "mock",
+      "echo",
+      '{"message": "{\\"name\\":\\"Evan\\"}"}',
+    );
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ name: "Evan" });
+  });
+
+  test("--format markdown renders text through markdown formatter", async () => {
+    const proc = run(
+      "--format",
+      "markdown",
+      "exec",
+      "mock",
+      "echo",
+      '{"message": "**bold** text"}',
+    );
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+    // Should contain the text content (possibly with ANSI formatting)
+    expect(stdout).toContain("bold");
+    expect(stdout).toContain("text");
+  });
+
+  test("--format json matches default piped behavior", async () => {
+    const defaultProc = run("exec", "mock", "echo", '{"message": "test"}');
+    const jsonProc = run("--format", "json", "exec", "mock", "echo", '{"message": "test"}');
+    const [defaultExit, jsonExit] = await Promise.all([defaultProc.exited, jsonProc.exited]);
+    const defaultStdout = await new Response(defaultProc.stdout).text();
+    const jsonStdout = await new Response(jsonProc.stdout).text();
+    expect(defaultExit).toBe(0);
+    expect(jsonExit).toBe(0);
+    expect(jsonStdout.trim()).toBe(defaultStdout.trim());
+  });
+
+  test("invalid --format value exits with error", async () => {
+    const proc = run("--format", "csv", "exec", "mock", "echo", '{"message": "test"}');
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Invalid format");
+  });
+
   test("--no-interactive declines elicitation requests", async () => {
     const proc = run("--no-interactive", "exec", "mock", "confirm_action", '{"action": "deploy"}');
     const exitCode = await proc.exited;

--- a/test/output/formatter.test.ts
+++ b/test/output/formatter.test.ts
@@ -225,8 +225,8 @@ describe("renderMarkdownToAnsi", () => {
     const stripped = ansis.strip(output);
     expect(stripped).toContain("Title");
     expect(stripped).toContain("Body");
-    // H1 should have rule lines
-    expect(stripped).toContain("─");
+    // H1 should have rule underline
+    expect(stripped).toContain("═");
   });
 
   test("renders links with href", () => {

--- a/test/output/formatter.test.ts
+++ b/test/output/formatter.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import ansis from "ansis";
-import { formatCallResult, wrapDescription } from "../../src/output/formatter.ts";
+import {
+  formatCallResult,
+  renderMarkdownToAnsi,
+  wrapDescription,
+} from "../../src/output/formatter.ts";
 
 describe("formatCallResult nested JSON parsing", () => {
   test("parses JSON strings inside text content", () => {
@@ -51,6 +55,185 @@ describe("formatCallResult nested JSON parsing", () => {
     };
     const parsed = JSON.parse(formatCallResult(result, {}));
     expect(parsed.isError).toBe(false);
+  });
+});
+
+describe("formatCallResult with format: text", () => {
+  const opts = { format: "text" as const };
+
+  test("extracts plain text from content blocks", () => {
+    const result = {
+      content: [{ type: "text", text: "hello world" }],
+    };
+    expect(formatCallResult(result, opts)).toBe("hello world");
+  });
+
+  test("pretty-prints JSON text content", () => {
+    const result = {
+      content: [{ type: "text", text: '{"name":"Evan","count":42}' }],
+    };
+    const output = formatCallResult(result, opts);
+    expect(JSON.parse(output)).toEqual({ name: "Evan", count: 42 });
+    // Should be pretty-printed with indentation
+    expect(output).toContain("\n");
+  });
+
+  test("joins multiple text blocks with newlines", () => {
+    const result = {
+      content: [
+        { type: "text", text: "line one" },
+        { type: "text", text: "line two" },
+      ],
+    };
+    expect(formatCallResult(result, opts)).toBe("line one\nline two");
+  });
+
+  test("shows placeholder for image content", () => {
+    const result = {
+      content: [{ type: "image", mimeType: "image/png", data: "AAAA" }],
+    };
+    expect(formatCallResult(result, opts)).toContain("[image: image/png,");
+  });
+
+  test("shows placeholder for resource content", () => {
+    const result = {
+      content: [{ type: "resource", uri: "file:///hello.txt" }],
+    };
+    expect(formatCallResult(result, opts)).toBe("[resource: file:///hello.txt]");
+  });
+
+  test("prefixes error results with error:", () => {
+    const result = {
+      content: [{ type: "text", text: "something went wrong" }],
+      isError: true,
+    };
+    expect(formatCallResult(result, opts)).toBe("error: something went wrong");
+  });
+
+  test("falls back to JSON for non-standard result shapes", () => {
+    const result = { unexpected: "data" };
+    const output = formatCallResult(result, opts);
+    expect(JSON.parse(output)).toEqual({ unexpected: "data" });
+  });
+
+  test("handles empty content array", () => {
+    const result = { content: [] };
+    const output = formatCallResult(result, opts);
+    expect(JSON.parse(output)).toEqual({ content: [] });
+  });
+
+  test("handles unknown content types", () => {
+    const result = {
+      content: [{ type: "custom_widget" }],
+    };
+    expect(formatCallResult(result, opts)).toBe("[custom_widget]");
+  });
+});
+
+describe("formatCallResult with format: markdown", () => {
+  const opts = { format: "markdown" as const };
+
+  test("renders plain text through markdown", () => {
+    const result = {
+      content: [{ type: "text", text: "hello world" }],
+    };
+    const output = formatCallResult(result, opts);
+    // Should contain the text (possibly with ANSI codes and trailing whitespace)
+    expect(ansis.strip(output).trim()).toContain("hello world");
+  });
+
+  test("renders bold/italic markdown content", () => {
+    const result = {
+      content: [{ type: "text", text: "**bold** and *italic*" }],
+    };
+    const output = formatCallResult(result, opts);
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("bold");
+    expect(stripped).toContain("italic");
+  });
+
+  test("renders headings with bold styling", () => {
+    const result = {
+      content: [{ type: "text", text: "# Title\n\nBody text" }],
+    };
+    const output = formatCallResult(result, opts);
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("Title");
+    expect(stripped).toContain("Body text");
+  });
+
+  test("renders code blocks with borders", () => {
+    const result = {
+      content: [{ type: "text", text: "```js\nconsole.log(42)\n```" }],
+    };
+    const output = formatCallResult(result, opts);
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("console.log(42)");
+    expect(stripped).toContain("│");
+  });
+});
+
+describe("formatCallResult with format: json (explicit)", () => {
+  test("behaves identically to default", () => {
+    const result = {
+      content: [{ type: "text", text: '{"name":"Evan"}' }],
+    };
+    const defaultOutput = formatCallResult(result, {});
+    const jsonOutput = formatCallResult(result, { format: "json" });
+    expect(jsonOutput).toBe(defaultOutput);
+  });
+});
+
+describe("renderMarkdownToAnsi", () => {
+  test("renders basic markdown preserving text", () => {
+    const output = renderMarkdownToAnsi("**hello** world");
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("hello");
+    expect(stripped).toContain("world");
+  });
+
+  test("renders lists with bullet markers", () => {
+    const output = renderMarkdownToAnsi("- item 1\n- item 2");
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("item 1");
+    expect(stripped).toContain("item 2");
+    expect(stripped).toContain("•");
+  });
+
+  test("renders inline code", () => {
+    const output = renderMarkdownToAnsi("use `foo()` here");
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("foo()");
+  });
+
+  test("renders code blocks with border characters", () => {
+    const output = renderMarkdownToAnsi("```js\nconst x = 1;\n```");
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("const x = 1;");
+    expect(stripped).toContain("│");
+  });
+
+  test("renders blockquotes with border", () => {
+    const output = renderMarkdownToAnsi("> quoted text");
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("quoted text");
+    expect(stripped).toContain("│");
+  });
+
+  test("renders headings", () => {
+    const output = renderMarkdownToAnsi("# Title\n\nBody");
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("Title");
+    expect(stripped).toContain("Body");
+    // H1 should have rule lines
+    expect(stripped).toContain("─");
+  });
+
+  test("renders links with href", () => {
+    const output = renderMarkdownToAnsi("[click](https://example.com)");
+    const stripped = ansis.strip(output);
+    expect(stripped).toContain("click");
+    expect(stripped).toContain("https://example.com");
   });
 });
 

--- a/test/output/formatter.test.ts
+++ b/test/output/formatter.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 import ansis from "ansis";
 import {
   formatCallResult,
+  jsonToMarkdown,
   renderMarkdownToAnsi,
   wrapDescription,
 } from "../../src/output/formatter.ts";
@@ -170,6 +171,76 @@ describe("formatCallResult with format: markdown", () => {
     const stripped = ansis.strip(output);
     expect(stripped).toContain("console.log(42)");
     expect(stripped).toContain("│");
+  });
+
+  test("renders JSON content as a structured markdown document", () => {
+    const result = {
+      content: [{ type: "text", text: '{"name":"Evan","active":true}' }],
+    };
+    const output = formatCallResult(result, opts);
+    const stripped = ansis.strip(output);
+    // Keys become headings, values become text
+    expect(stripped).toContain("Name");
+    expect(stripped).toContain("Evan");
+    expect(stripped).toContain("Active");
+    expect(stripped).toContain("true");
+  });
+});
+
+describe("jsonToMarkdown", () => {
+  test("renders primitive values as plain text", () => {
+    expect(jsonToMarkdown("hello")).toBe("hello");
+    expect(jsonToMarkdown(42)).toBe("42");
+    expect(jsonToMarkdown(true)).toBe("true");
+    expect(jsonToMarkdown(null)).toBe("null");
+  });
+
+  test("renders flat object with keys as h1 headings", () => {
+    const md = jsonToMarkdown({ display_name: "Evan", active: true });
+    expect(md).toContain("# Display Name\n\nEvan");
+    expect(md).toContain("# Active\n\ntrue");
+  });
+
+  test("humanizes key names", () => {
+    const md = jsonToMarkdown({ my_email_address: "a@b.com", firstName: "Evan" });
+    expect(md).toContain("# My Email Address");
+    expect(md).toContain("# First Name");
+  });
+
+  test("renders nested objects with increasing heading depth", () => {
+    const md = jsonToMarkdown({ user: { name: "Evan", role: "admin" } });
+    expect(md).toContain("# User");
+    expect(md).toContain("## Name\n\nEvan");
+    expect(md).toContain("## Role\n\nadmin");
+  });
+
+  test("renders arrays of primitives as bullet lists", () => {
+    const md = jsonToMarkdown({ tags: ["a", "b", "c"] });
+    expect(md).toContain("# Tags");
+    expect(md).toContain("- a\n- b\n- c");
+  });
+
+  test("renders arrays of objects with numbered sub-sections", () => {
+    const md = jsonToMarkdown({
+      teams: [
+        { name: "Engineering", key: "ENG" },
+        { name: "Product", key: "PRO" },
+      ],
+    });
+    expect(md).toContain("# Teams");
+    expect(md).toContain("## 1");
+    expect(md).toContain("### Name\n\nEngineering");
+    expect(md).toContain("### Key\n\nENG");
+    expect(md).toContain("## 2");
+    expect(md).toContain("### Name\n\nProduct");
+  });
+
+  test("caps heading depth at 6 and uses bold labels beyond", () => {
+    // depth 7+ should use **bold** instead of headings
+    const deep = { a: { b: { c: { d: { e: { f: { g: "deep" } } } } } } };
+    const md = jsonToMarkdown(deep);
+    expect(md).toContain("###### F");
+    expect(md).toContain("**G:** deep");
   });
 });
 


### PR DESCRIPTION
## Summary
Add a new global `--format` / `-F` flag that allows users to control how tool results are displayed. Previously, results were always shown as JSON. Now users can choose between `json` (default), `text` (extract plain text from content blocks), and `markdown` (render with ANSI styling).

## Key Changes

- **New `--format` flag**: Global option accepting `json`, `text`, or `markdown`
  - `json`: Full MCP protocol response (default, backward compatible)
  - `text`: Extract text from content blocks, pretty-print embedded JSON, show placeholders for images/resources
  - `markdown`: Render text through Bun's markdown parser with ANSI styling (colors, borders, formatting)

- **New `renderMarkdownToAnsi()` function**: Converts markdown to terminal-friendly ANSI output using Bun's built-in markdown parser
  - Supports headings (with rule lines), bold/italic, code blocks (with borders), blockquotes, lists, links, and more
  - Respects terminal width for rule lines

- **Refactored `formatCallResult()`**: Now dispatches on format option instead of always returning JSON
  - `formatCallResultAsText()`: Extracts text from MCP content blocks, handles JSON pretty-printing
  - `formatCallResultAsMarkdown()`: Applies markdown rendering to text output

- **Updated `formatOutput()`**: Respects explicit `--format` flag for non-exec commands
  - When format is set, uses JSON or interactive formatter accordingly
  - Falls back to existing auto-detection (interactive vs. piped) when not set

- **CLI integration**: Added format validation in `context.ts` with helpful error messages for invalid formats

- **Documentation**: Updated README and skills guide with format examples and use cases

## Implementation Details

- Format validation happens early in `getContext()` with clear error messaging
- The `text` format intelligently handles JSON strings within text blocks by parsing and pretty-printing them
- Markdown rendering uses Bun's native parser with custom handlers for terminal-friendly output (e.g., `│` borders for code blocks)
- Backward compatible: default behavior unchanged when flag is not specified
- Version bumped to 0.16.0

## Testing
Added comprehensive test coverage for all three formats including edge cases (empty content, unknown types, nested JSON, markdown features).

https://claude.ai/code/session_01UPWXYAdZjz4RUGePwAWATz