### PR TITLE
Make server name optional in mcpx exec

### DIFF
--- a/.claude/skills/mcpx.md
+++ b/.claude/skills/mcpx.md
@@ -25,7 +25,8 @@ This shows parameters, types, required fields, and the full JSON Schema.
 ## 3. Execute the tool
 
 ```bash
-mcpx exec <server> <tool> '<json args>'
+mcpx exec <tool> '<json args>'                # server auto-resolved if unambiguous
+mcpx exec <server> <tool> '<json args>'       # explicit server (required if tool name exists on multiple servers)
 mcpx exec <server> <tool> -f params.json
 ```
 
@@ -50,7 +51,10 @@ mcpx search "send a message"
 # See what parameters Slack_SendMessage needs
 mcpx info arcade Slack_SendMessage
 
-# Send a message
+# Send a message (server optional if tool name is unique)
+mcpx exec Slack_SendMessage '{"channel":"#general","message":"hello"}'
+
+# Or explicitly specify the server
 mcpx exec arcade Slack_SendMessage '{"channel":"#general","message":"hello"}'
 
 # Chain commands — search repos and read the first result
@@ -116,7 +120,8 @@ mcpx deauth <server>           # remove stored auth
 | `mcpx info <server>`                  | Server overview (version, capabilities, tools) |
 | `mcpx info <server> <tool>`           | Show tool schema                  |
 | `mcpx exec <server>`                  | List tools for a server           |
-| `mcpx exec <server> <tool> '<json>'`  | Execute a tool                    |
+| `mcpx exec <tool> '<json>'`           | Execute tool (server auto-resolved) |
+| `mcpx exec <server> <tool> '<json>'`  | Execute tool (explicit server)    |
 | `mcpx exec <server> <tool> -f file`   | Execute with args from file       |
 | `mcpx search "<query>"`               | Search tools (keyword + semantic) |
 | `mcpx search -k "<pattern>"`          | Keyword/glob search only          |

--- a/.cursor/rules/mcpx.mdc
+++ b/.cursor/rules/mcpx.mdc
@@ -25,9 +25,12 @@ This shows parameters, types, required fields, and the full JSON Schema.
 ## 3. Execute the tool
 
 ```bash
-mcpx exec <server> <tool> '<json args>'
+mcpx exec <tool> '<json args>'                # server auto-resolved if unambiguous
+mcpx exec <server> <tool> '<json args>'       # explicit server (required if tool name exists on multiple servers)
 mcpx exec <server> <tool> -f params.json
 ```
+
+Output is JSON when piped. Use `--json` to force JSON output in any context — prefer this when you need to parse results programmatically.
 
 ## Rules
 
@@ -35,6 +38,7 @@ mcpx exec <server> <tool> -f params.json
 - Always inspect the schema before executing — validate you have the right arguments
 - Use `mcpx search -k` for exact name matching
 - Pipe results through `jq` when you need to extract specific fields
+- Use `--json` when parsing output programmatically (automatic when piped, but explicit is safer)
 - Use `-v` for verbose debugging (HTTP details + JSON-RPC protocol messages) if an exec fails unexpectedly
 - Use `-l debug` to see all server log messages, or `-l error` for errors only
 
@@ -47,7 +51,10 @@ mcpx search "send a message"
 # See what parameters Slack_SendMessage needs
 mcpx info arcade Slack_SendMessage
 
-# Send a message
+# Send a message (server optional if tool name is unique)
+mcpx exec Slack_SendMessage '{"channel":"#general","message":"hello"}'
+
+# Or explicitly specify the server
 mcpx exec arcade Slack_SendMessage '{"channel":"#general","message":"hello"}'
 
 # Chain commands — search repos and read the first result
@@ -58,16 +65,22 @@ mcpx exec github search_repositories '{"query":"mcp"}' \
 # Read args from stdin
 echo '{"path":"./README.md"}' | mcpx exec filesystem read_file
 
-# Pipe from a file
-cat params.json | mcpx exec server tool
-
 # Read args from a file with --file flag
 mcpx exec filesystem read_file -f params.json
 ```
 
-## 4. Long-running tools (Tasks)
+## Troubleshooting
 
-Some tools support async execution via MCP Tasks. mcpx auto-detects this and uses task-augmented execution when available.
+- **"Not authenticated" / 401 error** → Run `mcpx auth <server>` to start the OAuth flow
+- **Exec timeout** → Use `-v` to see where it stalls; set `MCP_TIMEOUT=<seconds>` to increase the timeout (default: 1800)
+- **Search returns no results** → Try `mcpx search -k "*keyword*"` for glob matching, or `mcpx index` to rebuild the search index
+- **Missing or stale tools** → Run `mcpx index` to rebuild; any command that connects to a server also auto-updates the index
+- **Server won't connect** → Run `mcpx ping <server>` to check connectivity; use `-v` for protocol-level details
+- **Auth token expired** → Run `mcpx auth <server> -r` to force a token refresh
+
+## Long-running tools (Tasks)
+
+Some tools support async execution via MCP Tasks. mcpx auto-detects this.
 
 ```bash
 # Default: waits for the task to complete, showing progress
@@ -76,90 +89,122 @@ mcpx exec my-server long_running_tool '{"input": "data"}'
 # Return immediately with a task handle (for scripting/polling)
 mcpx exec my-server long_running_tool '{"input": "data"}' --no-wait
 
-# Check task status
+# Check task status / retrieve result / cancel
 mcpx task get my-server <taskId>
-
-# Retrieve the result once complete
 mcpx task result my-server <taskId>
-
-# List all tasks on a server
-mcpx task list my-server
-
-# Cancel a running task
 mcpx task cancel my-server <taskId>
+mcpx task list my-server
 ```
 
-For tools that don't support tasks, `exec` works exactly as before.
+## Elicitation (Server-Requested Input)
 
-## 5. Elicitation (Server-Requested Input)
-
-Some servers request user input mid-operation (e.g., confirmations, auth flows). mcpx handles this automatically:
-
-```bash
-# Interactive — prompts appear in the terminal
-mcpx exec my-server deploy_tool '{"target": "staging"}'
-# Server requests input: Confirm deployment
-#   *Confirm [y/n]: y
-
-# Non-interactive — decline all elicitation (for scripts/CI)
-mcpx exec my-server deploy_tool '{"target": "staging"}' --no-interactive
-
-# JSON mode — read/write elicitation as JSON via stdin/stdout
-echo '{"action":"accept","content":{"confirm":true}}' | \
-  mcpx exec my-server deploy_tool '{"target": "staging"}' --json
-```
+Some servers request user input mid-operation. mcpx handles this automatically in interactive mode. Use `-N` / `--no-interactive` to decline all elicitation (for scripts/CI), or `--json` to handle elicitation programmatically via stdin/stdout.
 
 ## Authentication
 
-Some HTTP servers require OAuth. If you see an "Not authenticated" error:
-
 ```bash
-mcpx auth <server>        # authenticate via browser
-mcpx auth <server> -s     # check token status and TTL
-mcpx auth <server> -r     # force token refresh
-mcpx deauth <server>      # remove stored auth
+mcpx auth <server>             # authenticate via browser
+mcpx auth <server> -s          # check token status and TTL
+mcpx auth <server> -r          # force token refresh
+mcpx auth <server> --no-index  # authenticate without rebuilding search index
+mcpx deauth <server>           # remove stored auth
 ```
 
 ## Available commands
 
 | Command                                | Purpose                           |
 | -------------------------------------- | --------------------------------- |
-| `mcpx`                               | List all servers and tools        |
-| `mcpx servers`                       | List servers (name, type, detail) |
-| `mcpx -d`                            | List with descriptions            |
-| `mcpx info <server>`                 | Server overview (version, capabilities, tools) |
-| `mcpx info <server> <tool>`          | Show tool schema                  |
-| `mcpx exec <server>`                 | List tools for a server           |
-| `mcpx exec <server> <tool> '<json>'` | Execute a tool                    |
-| `mcpx exec <server> <tool> -f file`  | Execute with args from file       |
-| `mcpx search "<query>"`              | Search tools (keyword + semantic) |
-| `mcpx search -k "<pattern>"`         | Keyword/glob search only          |
-| `mcpx search -q "<query>"`           | Semantic search only              |
-| `mcpx search -n <number> "<query>"`  | Limit number of results (default: 10) |
-| `mcpx index`                         | Build/rebuild search index        |
-| `mcpx index -i`                      | Show index status                 |
-| `mcpx auth <server>`                 | Authenticate with OAuth           |
-| `mcpx auth <server> -s`              | Check token status and TTL        |
+| `mcpx`                                | List all servers and tools        |
+| `mcpx servers`                        | List servers (name, type, detail) |
+| `mcpx -d`                             | List with descriptions            |
+| `mcpx info <server>`                  | Server overview (version, capabilities, tools) |
+| `mcpx info <server> <tool>`           | Show tool schema                  |
+| `mcpx exec <server>`                  | List tools for a server           |
+| `mcpx exec <tool> '<json>'`           | Execute tool (server auto-resolved) |
+| `mcpx exec <server> <tool> '<json>'`  | Execute tool (explicit server)    |
+| `mcpx exec <server> <tool> -f file`   | Execute with args from file       |
+| `mcpx search "<query>"`               | Search tools (keyword + semantic) |
+| `mcpx search -k "<pattern>"`          | Keyword/glob search only          |
+| `mcpx search -q "<query>"`            | Semantic search only              |
+| `mcpx search -n <number> "<query>"`   | Limit number of results (default: 10) |
+| `mcpx index`                          | Build/rebuild search index        |
+| `mcpx index -i`                       | Show index status                 |
+| `mcpx auth <server>`                  | Authenticate with OAuth           |
+| `mcpx auth <server> -s`               | Check token status and TTL        |
 | `mcpx auth <server> -r`              | Force token refresh               |
-| `mcpx deauth <server>`               | Remove stored authentication      |
-| `mcpx ping`                          | Check connectivity to all servers |
-| `mcpx ping <server> [server2...]`    | Check specific server(s)          |
-| `mcpx add <name> --command <cmd>`    | Add a stdio MCP server            |
-| `mcpx add <name> --url <url>`        | Add an HTTP MCP server            |
-| `mcpx add <name> --url <url> --transport sse` | Add a legacy SSE server  |
-| `mcpx remove <name>`                 | Remove an MCP server              |
-| `mcpx skill install --claude`        | Install mcpx skill for Claude   |
-| `mcpx skill install --cursor`        | Install mcpx rule for Cursor    |
-| `mcpx resource`                     | List all resources across servers |
-| `mcpx resource <server>`            | List resources for a server       |
-| `mcpx resource <server> <uri>`      | Read a specific resource          |
-| `mcpx prompt`                       | List all prompts across servers   |
-| `mcpx prompt <server>`              | List prompts for a server         |
-| `mcpx prompt <server> <name> '<json>'` | Get a specific prompt          |
-| `mcpx exec <server> <tool> --no-wait` | Execute as async task, return handle |
-| `mcpx exec <server> <tool> --ttl <ms>` | Set task TTL (default: 60000) |
-| `mcpx -N exec <server> <tool> ...`  | Decline elicitation (non-interactive) |
-| `mcpx task list <server>`            | List tasks on a server          |
-| `mcpx task get <server> <taskId>`    | Get task status                 |
-| `mcpx task result <server> <taskId>` | Retrieve completed task result  |
-| `mcpx task cancel <server> <taskId>` | Cancel a running task           |
+| `mcpx auth <server> --no-index`       | Authenticate without rebuilding index |
+| `mcpx deauth <server>`                | Remove stored authentication      |
+| `mcpx ping`                           | Check connectivity to all servers |
+| `mcpx ping <server> [server2...]`     | Check specific server(s)          |
+| `mcpx add <name> --command <cmd>`     | Add a stdio MCP server            |
+| `mcpx add <name> --url <url>`         | Add an HTTP MCP server            |
+| `mcpx remove <name>`                  | Remove an MCP server              |
+| `mcpx skill install --claude`         | Install mcpx skill for Claude     |
+| `mcpx skill install --cursor`         | Install mcpx rule for Cursor      |
+| `mcpx resource`                       | List all resources across servers |
+| `mcpx resource <server>`              | List resources for a server       |
+| `mcpx resource <server> <uri>`        | Read a specific resource          |
+| `mcpx prompt`                         | List all prompts across servers   |
+| `mcpx prompt <server>`                | List prompts for a server         |
+| `mcpx prompt <server> <name> '<json>'` | Get a specific prompt            |
+| `mcpx task list <server>`             | List tasks on a server            |
+| `mcpx task get <server> <taskId>`     | Get task status                   |
+| `mcpx task result <server> <taskId>`  | Retrieve completed task result    |
+| `mcpx task cancel <server> <taskId>`  | Cancel a running task             |
+
+## Global flags
+
+| Flag                      | Purpose                                                  |
+| ------------------------- | -------------------------------------------------------- |
+| `-j, --json`              | Force JSON output (default when piped)                   |
+| `-v, --verbose`           | Show HTTP details and JSON-RPC protocol messages         |
+| `-d, --with-descriptions` | Include tool descriptions in list output                 |
+| `-c, --config <path>`     | Specify config file location                             |
+| `-N, --no-interactive`    | Decline server elicitation requests (for scripted usage) |
+| `-S, --show-secrets`      | Show full auth tokens in verbose output (unmasked)       |
+| `-l, --log-level <level>` | Minimum server log level to display (default: `warning`) |
+
+## `add` options
+
+| Flag                       | Purpose                                |
+| -------------------------- | -------------------------------------- |
+| `--command <cmd>`          | Command to run (stdio server)          |
+| `--args <a1,a2,...>`       | Comma-separated arguments              |
+| `--env <KEY=VAL,...>`      | Comma-separated environment variables  |
+| `--cwd <dir>`              | Working directory for the command      |
+| `--url <url>`              | Server URL (HTTP server)               |
+| `--header <Key:Value>`     | HTTP header (repeatable)               |
+| `--transport <type>`       | Transport: `sse` or `streamable-http`  |
+| `--allowed-tools <t1,t2>`  | Comma-separated allowed tool patterns  |
+| `--disabled-tools <t1,t2>` | Comma-separated disabled tool patterns |
+| `-f, --force`              | Overwrite if server already exists     |
+| `--no-auth`                | Skip automatic OAuth after adding      |
+| `--no-index`               | Skip rebuilding the search index       |
+
+## `remove` options
+
+| Flag          | Purpose                                          |
+| ------------- | ------------------------------------------------ |
+| `--keep-auth` | Don't remove stored auth credentials             |
+| `--dry-run`   | Show what would be removed without changing files |
+
+## `skill install` options
+
+| Flag        | Purpose                                    |
+| ----------- | ------------------------------------------ |
+| `--claude`  | Install skill for Claude Code              |
+| `--cursor`  | Install rule for Cursor                    |
+| `--global`  | Install to global location (`~/`)          |
+| `--project` | Install to project location (default)      |
+| `-f, --force` | Overwrite if file already exists         |
+
+## Environment variables
+
+| Variable          | Purpose                     | Default    |
+| ----------------- | --------------------------- | ---------- |
+| `MCP_CONFIG_PATH` | Config directory path       | `~/.mcpx/` |
+| `MCP_TIMEOUT`     | Request timeout (seconds)   | `1800`     |
+| `MCP_CONCURRENCY` | Parallel server connections | `5`        |
+| `MCP_MAX_RETRIES` | Retry attempts              | `3`        |
+| `MCP_STRICT_ENV`  | Error on missing `${VAR}`   | `true`     |
+| `MCP_DEBUG`       | Enable debug output         | `false`    |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ mcpx — A CLI for MCP servers. "curl for MCP."
 ## Rules
 
 - **Always bump the patch version in `package.json`** when making any code changes (source, tests, config). Use semver: patch for fixes/small changes, minor for new features, major for breaking changes.
-- **Always keep `README.md` and `.claude/skills/mcpx.md` in sync** with any CLI changes (commands, flags, syntax, examples). The skill file includes workflow steps, code examples, and a command table that must all reflect the current CLI surface.
+- **Always keep `README.md`, `.claude/skills/mcpx.md`, and `.cursor/rules/mcpx.mdc` in sync** with any CLI changes (commands, flags, syntax, examples). Both skill files include workflow steps, code examples, and a command table that must all reflect the current CLI surface.
 - **Always run `bun run format`** before committing to fix prettier formatting issues.
 - **Never merge or auto-merge a PR without explicit human approval.** Create the PR and report the URL, but do not merge it. The human will review and merge manually.
 - **When a PR closes a GitHub issue, include `Closes <issue URL>` in the PR body** (e.g., `Closes https://github.com/evantahler/mcpx/issues/29`). This lets GitHub auto-close the issue when the PR is merged.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ mcpx info github search_repositories
 # Execute a tool
 mcpx exec github search_repositories '{"query": "mcp server"}'
 
+# Execute a tool without specifying the server (auto-resolved)
+mcpx exec search_repositories '{"query": "mcp server"}'
+
 # Search tools — combines keyword and semantic matching
 mcpx search "post a ticket to linear"
 
@@ -70,6 +73,7 @@ mcpx search -n 5 "manage pull requests"
 | `mcpx index`                           | Build/rebuild the search index                         |
 | `mcpx index -i`                        | Show index status                                      |
 | `mcpx exec <server> <tool> [json]`     | Validate inputs locally, then execute tool             |
+| `mcpx exec <tool> [json]`              | Execute tool (server auto-resolved if unambiguous)     |
 | `mcpx exec <server> <tool> -f file`    | Read tool args from a JSON file                        |
 | `mcpx exec <server>`                   | List available tools for a server                      |
 | `mcpx auth <server>`                   | Authenticate with an HTTP MCP server (OAuth)           |
@@ -89,8 +93,8 @@ mcpx search -n 5 "manage pull requests"
 | `mcpx prompt`                          | List all prompts across all servers                    |
 | `mcpx prompt <server>`                 | List prompts for a server                              |
 | `mcpx prompt <server> <name> [json]`   | Get a specific prompt                                  |
-| `mcpx exec <server> <tool> --no-wait`  | Execute as async task, return task handle immediately  |
-| `mcpx exec <server> <tool> --ttl <ms>` | Set task TTL in milliseconds (default: 60000)          |
+| `mcpx exec [server] <tool> --no-wait`  | Execute as async task, return task handle immediately  |
+| `mcpx exec [server] <tool> --ttl <ms>` | Set task TTL in milliseconds (default: 60000)          |
 | `mcpx task list <server>`              | List tasks on a server                                 |
 | `mcpx task get <server> <taskId>`      | Get task status                                        |
 | `mcpx task result <server> <taskId>`   | Retrieve completed task result                         |
@@ -549,7 +553,7 @@ Then in any Claude Code session, the agent can use `/mcpx` or the skill triggers
 
 1. **Search first** — `mcpx search "<intent>"` to find relevant tools
 2. **Inspect** — `mcpx info <server> <tool>` to get the schema before calling
-3. **Execute** — `mcpx exec <server> <tool> '<json>'` to execute
+3. **Execute** — `mcpx exec <tool> '<json>'` to execute (or `mcpx exec <server> <tool> '<json>'` if the tool name is ambiguous)
 
 This keeps tool schemas out of the system prompt entirely. The agent discovers what it needs on-demand, saving tokens and context window space.
 
@@ -584,7 +588,8 @@ To discover tools:
   mcpx info <server> <tool>              # tool schema
 
 To execute tools:
-  mcpx exec <server> <tool> '<json args>'
+  mcpx exec <tool> '<json args>'              # server auto-resolved
+  mcpx exec <server> <tool> '<json args>'     # explicit server
   mcpx exec <server> <tool> -f params.json
 
 Always search before executing — don't assume tool names.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.15.9",
+  "version": "0.16.0",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -11,27 +11,83 @@ import { logger } from "../output/logger.ts";
 import { validateToolInput } from "../validation/schema.ts";
 import { parseJsonArgs, readStdin } from "../lib/input.ts";
 import { DEFAULTS } from "../constants.ts";
+import type { ServerManager } from "../client/manager.ts";
+
+type ResolvedArgs =
+  | { mode: "list-tools"; server: string }
+  | { mode: "call-tool"; server: string; tool: string; argsStr: string | undefined };
+
+/**
+ * Resolve the positional args into either list-tools or call-tool mode.
+ * Supports both `exec <server> <tool> [args]` and `exec <tool> [args]`.
+ */
+async function resolveExecArgs(
+  manager: ServerManager,
+  first: string,
+  second: string | undefined,
+  third: string | undefined,
+): Promise<ResolvedArgs> {
+  const serverNames = manager.getServerNames();
+  const isServer = serverNames.includes(first);
+
+  if (isServer) {
+    // Traditional form: exec <server> [tool] [args]
+    if (!second) {
+      return { mode: "list-tools", server: first };
+    }
+    return { mode: "call-tool", server: first, tool: second, argsStr: third };
+  }
+
+  // Not a server name — treat first as a tool name
+  const toolName = first;
+  const { tools } = await manager.getAllTools();
+  const matches = tools.filter((t) => t.tool.name === toolName);
+
+  if (matches.length === 0) {
+    throw new Error(
+      `Unknown server or tool "${first}". Run "mcpx search ${first}" to find similar tools.`,
+    );
+  }
+
+  if (matches.length > 1) {
+    const servers = matches.map((m) => m.server).join(", ");
+    throw new Error(
+      `Ambiguous tool "${toolName}" — found on multiple servers: ${servers}\nSpecify the server: mcpx exec <server> ${toolName} [args]`,
+    );
+  }
+
+  return { mode: "call-tool", server: matches[0]!.server, tool: toolName, argsStr: second };
+}
 
 export function registerExecCommand(program: Command) {
   program
-    .command("exec <server> [tool] [args]")
-    .description("execute a tool (omit tool name to list available tools)")
+    .command("exec <first> [second] [third]")
+    .description("execute a tool (server is optional if tool name is unambiguous)")
     .option("-f, --file <path>", "read JSON args from a file")
     .option("--no-wait", "return task handle immediately without waiting for completion")
     .option("--ttl <ms>", "task TTL in milliseconds", String(DEFAULTS.TASK_TTL_MS))
     .action(
       async (
-        server: string,
-        tool: string | undefined,
-        argsStr: string | undefined,
+        first: string,
+        second: string | undefined,
+        third: string | undefined,
         options: { file?: string; wait: boolean; ttl: string },
       ) => {
         const { manager, formatOptions } = await getContext(program);
 
-        if (!tool) {
+        let resolved: ResolvedArgs;
+        try {
+          resolved = await resolveExecArgs(manager, first, second, third);
+        } catch (err) {
+          console.error(formatError(String(err), formatOptions));
+          await manager.close();
+          process.exit(1);
+        }
+
+        if (resolved.mode === "list-tools") {
           try {
-            const tools = await manager.listTools(server);
-            console.log(formatServerTools(server, tools, formatOptions));
+            const tools = await manager.listTools(resolved.server);
+            console.log(formatServerTools(resolved.server, tools, formatOptions));
           } catch (err) {
             console.error(formatError(String(err), formatOptions));
             process.exit(1);
@@ -40,6 +96,9 @@ export function registerExecCommand(program: Command) {
           }
           return;
         }
+
+        const { server, tool, argsStr } = resolved;
+
         try {
           // Error if both --file and positional arg provided
           if (options.file && argsStr) {

--- a/test/commands/exec.test.ts
+++ b/test/commands/exec.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, afterAll } from "bun:test";
 import { join } from "path";
 import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
-import { run, runWithStdin, CLI, CONFIG } from "../helpers/run.ts";
+import { run, runWithStdin, runMultiServer, CLI, CONFIG } from "../helpers/run.ts";
 
 const tempDir = mkdtempSync(join(tmpdir(), "mcpx-test-"));
 afterAll(() => rmSync(tempDir, { recursive: true, force: true }));
@@ -143,5 +143,87 @@ describe("mcpx exec", () => {
 
     const result = JSON.parse(stdout);
     expect(result.content[0].text).toContain("declined");
+  });
+});
+
+describe("mcpx exec (server-optional)", () => {
+  test("resolves tool without server when unambiguous", async () => {
+    const proc = run("exec", "echo", '{"message": "no server"}');
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.content[0].text).toBe("no server");
+  });
+
+  test("resolves add tool without server", async () => {
+    const proc = run("exec", "add", '{"a": 3, "b": 7}');
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.content[0].text).toBe(10);
+  });
+
+  test("errors on unknown tool name", async () => {
+    const proc = run("exec", "nonexistent_tool");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unknown server or tool");
+    expect(stderr).toContain("mcpx search");
+  });
+
+  test("backwards compat: server + tool still works", async () => {
+    const proc = run("exec", "mock", "echo", '{"message": "compat"}');
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.content[0].text).toBe("compat");
+  });
+
+  test("backwards compat: server-only lists tools", async () => {
+    const proc = run("exec", "mock");
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("echo");
+    expect(stdout).toContain("add");
+  });
+});
+
+describe("mcpx exec (multi-server disambiguation)", () => {
+  test("errors on ambiguous tool across servers", async () => {
+    const proc = runMultiServer("exec", "echo", '{"message": "hi"}');
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Ambiguous tool");
+    expect(stderr).toContain("mock");
+    expect(stderr).toContain("mock2");
+  });
+
+  test("resolves unique tool across servers", async () => {
+    const proc = runMultiServer("exec", "multiply", '{"a": 4, "b": 5}');
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.content[0].text).toBe(20);
+  });
+
+  test("server + tool still works with multi-server config", async () => {
+    const proc = runMultiServer("exec", "mock", "echo", '{"message": "explicit"}');
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.content[0].text).toBe("explicit");
   });
 });

--- a/test/fixtures/mock-server-2.ts
+++ b/test/fixtures/mock-server-2.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+
+/**
+ * Second minimal MCP server for testing tool disambiguation.
+ * Has `echo` (overlaps with mock) and `multiply` (unique).
+ */
+
+let buffer = "";
+
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (chunk: string) => {
+  buffer += chunk;
+  processBuffer();
+});
+
+function processBuffer() {
+  while (true) {
+    const newlineIndex = buffer.indexOf("\n");
+    if (newlineIndex === -1) break;
+    const line = buffer.slice(0, newlineIndex).trim();
+    buffer = buffer.slice(newlineIndex + 1);
+    if (line) handleMessage(line);
+  }
+}
+
+function handleMessage(line: string) {
+  let msg: { jsonrpc: string; id?: number; method?: string; params?: unknown };
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  if (msg.method === "initialize") {
+    respond(msg.id, {
+      protocolVersion: "2025-03-26",
+      capabilities: { tools: {} },
+      serverInfo: { name: "mock-server-2", version: "1.0.0" },
+    });
+  } else if (msg.method === "notifications/initialized") {
+    // No response needed
+  } else if (msg.method === "tools/list") {
+    respond(msg.id, {
+      tools: [
+        {
+          name: "echo",
+          description: "Echoes back the input (server 2)",
+          inputSchema: {
+            type: "object",
+            properties: {
+              message: { type: "string", description: "Message to echo" },
+            },
+            required: ["message"],
+          },
+        },
+        {
+          name: "multiply",
+          description: "Multiplies two numbers",
+          inputSchema: {
+            type: "object",
+            properties: {
+              a: { type: "number" },
+              b: { type: "number" },
+            },
+            required: ["a", "b"],
+          },
+        },
+      ],
+    });
+  } else if (msg.method === "logging/setLevel") {
+    respond(msg.id, {});
+  } else if (msg.method === "tools/call") {
+    const params = msg.params as {
+      name: string;
+      arguments?: Record<string, unknown>;
+    };
+    if (params.name === "echo") {
+      respond(msg.id, {
+        content: [{ type: "text", text: String(params.arguments?.message ?? "") }],
+      });
+    } else if (params.name === "multiply") {
+      const a = Number(params.arguments?.a ?? 0);
+      const b = Number(params.arguments?.b ?? 0);
+      respond(msg.id, {
+        content: [{ type: "text", text: String(a * b) }],
+      });
+    } else {
+      respond(msg.id, {
+        content: [{ type: "text", text: `unknown tool: ${params.name}` }],
+        isError: true,
+      });
+    }
+  } else if (msg.method === "ping") {
+    respond(msg.id, {});
+  }
+}
+
+function respond(id: number | undefined, result: unknown) {
+  if (id === undefined) return;
+  const response = JSON.stringify({ jsonrpc: "2.0", id, result });
+  process.stdout.write(response + "\n");
+}

--- a/test/fixtures/multi-server-config/servers.json
+++ b/test/fixtures/multi-server-config/servers.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "mock": {
+      "command": "bun",
+      "args": ["run", "test/fixtures/mock-server.ts"]
+    },
+    "mock2": {
+      "command": "bun",
+      "args": ["run", "test/fixtures/mock-server-2.ts"]
+    }
+  }
+}

--- a/test/helpers/run.ts
+++ b/test/helpers/run.ts
@@ -2,6 +2,7 @@ import { join } from "path";
 
 const CLI = join(import.meta.dir, "../../src/cli.ts");
 const CONFIG = join(import.meta.dir, "../fixtures/mock-config");
+const MULTI_CONFIG = join(import.meta.dir, "../fixtures/multi-server-config");
 const CWD = join(import.meta.dir, "../..");
 
 /** Spawn the CLI with the mock config and the given args. */
@@ -31,4 +32,13 @@ export function runJson(...args: string[]) {
   return run("--json", ...args);
 }
 
-export { CLI, CONFIG, CWD };
+/** Spawn the CLI with the multi-server config and the given args. */
+export function runMultiServer(...args: string[]) {
+  return Bun.spawn(["bun", "run", CLI, "-c", MULTI_CONFIG, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: CWD,
+  });
+}
+
+export { CLI, CONFIG, MULTI_CONFIG, CWD };


### PR DESCRIPTION
## Summary
- `mcpx exec <tool> '<args>'` now works when the tool name is unambiguous across configured servers — no need to specify the server
- If a tool exists on multiple servers, an error lists them so the user can disambiguate with `mcpx exec <server> <tool> '<args>'`
- Full backwards compatibility: `mcpx exec <server> <tool>` and `mcpx exec <server>` (list tools) still work as before

## Test plan
- [x] 8 new tests covering: server-optional resolution, unknown tool errors, backwards compat, multi-server ambiguity, unique tool resolution across servers
- [x] All 22 exec tests pass (14 existing + 8 new)
- [x] All 75 command tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)