### PR TITLE
Validate tool exists on specified server in exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -35,6 +35,31 @@ async function resolveExecArgs(
     if (!second) {
       return { mode: "list-tools", server: first };
     }
+
+    // Validate the tool exists on the specified server
+    const serverTools = await manager.listTools(first);
+    const toolExists = serverTools.some((t) => t.name === second);
+
+    if (!toolExists) {
+      const { tools } = await manager.getAllTools();
+      const matches = tools.filter((t) => t.tool.name === second);
+
+      if (matches.length === 1) {
+        throw new Error(
+          `Tool "${second}" not found on server "${first}". Did you mean:\n  mcpx exec ${matches[0]!.server} ${second}`,
+        );
+      } else if (matches.length > 1) {
+        const servers = matches.map((m) => m.server).join(", ");
+        throw new Error(
+          `Tool "${second}" not found on server "${first}". Found on: ${servers}\nUsage: mcpx exec <server> ${second} [args]`,
+        );
+      } else {
+        throw new Error(
+          `Tool "${second}" not found on server "${first}". Run "mcpx search ${second}" to find similar tools.`,
+        );
+      }
+    }
+
     return { mode: "call-tool", server: first, tool: second, argsStr: third };
   }
 

--- a/test/commands/exec.test.ts
+++ b/test/commands/exec.test.ts
@@ -277,6 +277,25 @@ describe("mcpx exec (multi-server disambiguation)", () => {
     expect(result.content[0].text).toBe(20);
   });
 
+  test("errors when tool not found on specified server, suggests correct server", async () => {
+    // multiply only exists on mock2, not mock
+    const proc = runMultiServer("exec", "mock", "multiply", '{"a": 2, "b": 3}');
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("not found on server");
+    expect(stderr).toContain("mock2");
+  });
+
+  test("errors when tool not found on any server with explicit server", async () => {
+    const proc = run("exec", "mock", "nonexistent_tool");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("not found on server");
+    expect(stderr).toContain("mcpx search");
+  });
+
   test("server + tool still works with multi-server config", async () => {
     const proc = runMultiServer("exec", "mock", "echo", '{"message": "explicit"}');
     const exitCode = await proc.exited;


### PR DESCRIPTION
## Summary

- When running `mcpx exec <server> <tool>`, the CLI now validates that the tool exists on the specified server before sending the call
- If the tool is not found, it searches all servers and suggests the correct one (e.g., `Did you mean: mcpx exec evan-coding Linear_ListTeams`)
- Previously, misrouted calls would produce a confusing MCP gateway error ("tool not enabled for this gateway")

## Test plan

- [x] Added test: tool not found on specified server suggests correct server
- [x] Added test: tool not found anywhere with explicit server suggests `mcpx search`
- [x] All 29 existing exec tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)