### PR TITLE
Add PowerShell install script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,19 @@ Two audiences:
 ## Install
 
 ```bash
-# Via bun
+# Via bun (all platforms)
 bun install -g @evantahler/mcpx
 
-# Via curl
+# Via curl (macOS/Linux)
 curl -fsSL https://raw.githubusercontent.com/evantahler/mcpx/main/install.sh | bash
 ```
 
-The curl installer downloads a pre-built binary (macOS/Linux) — no runtime needed. The bun install method requires [Bun](https://bun.sh). Windows `.exe` binaries are available on the [GitHub Releases](https://github.com/evantahler/mcpx/releases) page.
+```powershell
+# Via PowerShell (Windows)
+irm https://raw.githubusercontent.com/evantahler/mcpx/main/install.ps1 | iex
+```
+
+The curl/PowerShell installers download a pre-built binary — no runtime needed. The bun install method requires [Bun](https://bun.sh). Binaries for all platforms are also available on the [GitHub Releases](https://github.com/evantahler/mcpx/releases) page.
 
 ## Quick Start
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,65 @@
+#!/usr/bin/env pwsh
+# install.ps1 — Install mcpx on Windows
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = "evantahler/mcpx"
+$InstallDir = if ($env:MCPX_INSTALL_DIR) { $env:MCPX_INSTALL_DIR } else { "$env:LOCALAPPDATA\mcpx" }
+
+# Detect architecture
+$Arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64" { "x64" }
+    "ARM64" { "arm64" }
+    default {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+$Artifact = "mcpx-windows-${Arch}.exe"
+
+# Get latest release tag
+Write-Host "Fetching latest release..."
+try {
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ "User-Agent" = "mcpx-installer" }
+    $Tag = $Release.tag_name
+}
+catch {
+    Write-Error "Could not determine latest release: $_"
+    exit 1
+}
+
+if (-not $Tag) {
+    Write-Error "Could not determine latest release tag"
+    exit 1
+}
+
+$Url = "https://github.com/$Repo/releases/download/$Tag/$Artifact"
+
+# Create install directory if needed
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+
+$OutFile = Join-Path $InstallDir "mcpx.exe"
+
+# Download
+Write-Host "Downloading mcpx $Tag (windows/$Arch)..."
+try {
+    Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
+}
+catch {
+    Write-Error "Download failed: $_"
+    exit 1
+}
+
+# Add to PATH if not already there
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    Write-Host "Adding $InstallDir to user PATH..."
+    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
+    $env:Path = "$env:Path;$InstallDir"
+    Write-Host "Restart your terminal for PATH changes to take effect."
+}
+
+Write-Host "mcpx $Tag installed to $OutFile"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Adds `install.ps1` — a PowerShell installer for Windows that mirrors the existing `install.sh` for macOS/Linux. Supports one-liner install via `irm ... | iex`, auto-detects architecture (x64/ARM64), downloads the correct `.exe` from GitHub releases, and adds the install directory to the user PATH.
- Updates `README.md` install section to include the PowerShell command alongside the existing curl command.
- Bumps version to 0.16.3.

## Test plan

- [ ] Verify `install.ps1` runs on Windows with `irm https://raw.githubusercontent.com/evantahler/mcpx/main/install.ps1 | iex`
- [ ] Verify architecture detection works for both x64 and ARM64
- [ ] Verify `$env:MCPX_INSTALL_DIR` override works
- [ ] Verify PATH is updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)