### PR TITLE
Add TypeScript SDK for programmatic MCP tool usage

### DIFF
--- a/.claude/skills/mcpx.md
+++ b/.claude/skills/mcpx.md
@@ -231,6 +231,22 @@ mcpx deauth <server>           # remove stored auth
 | `--project` | Install to project location (default)      |
 | `-f, --force` | Overwrite if file already exists         |
 
+## Programmatic Usage (TypeScript SDK)
+
+For agents that don't have shell access (remote, persistent, or isolated agents), mcpx can be used as a TypeScript library:
+
+```typescript
+import { McpxClient } from "@evantahler/mcpx";
+
+const client = new McpxClient();
+const results = await client.search("send a message");
+const tool = await client.info("arcade", "Slack_SendMessage");
+const result = await client.exec("arcade", "Slack_SendMessage", { channel: "#general", message: "hello" });
+await client.close();
+```
+
+The SDK follows the same search → inspect → exec workflow. Server management (add, remove, auth) is still done via the CLI.
+
 ## Environment variables
 
 | Variable          | Purpose                     | Default    |

--- a/.cursor/rules/mcpx.mdc
+++ b/.cursor/rules/mcpx.mdc
@@ -225,6 +225,22 @@ mcpx deauth <server>           # remove stored auth
 | `--project` | Install to project location (default)      |
 | `-f, --force` | Overwrite if file already exists         |
 
+## Programmatic Usage (TypeScript SDK)
+
+For agents that don't have shell access (remote, persistent, or isolated agents), mcpx can be used as a TypeScript library:
+
+```typescript
+import { McpxClient } from "@evantahler/mcpx";
+
+const client = new McpxClient();
+const results = await client.search("send a message");
+const tool = await client.info("arcade", "Slack_SendMessage");
+const result = await client.exec("arcade", "Slack_SendMessage", { channel: "#general", message: "hello" });
+await client.close();
+```
+
+The SDK follows the same search → inspect → exec workflow. Server management (add, remove, auth) is still done via the CLI.
+
 ## Environment variables
 
 | Variable          | Purpose                     | Default    |

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ A command-line interface for MCP servers. **curl for MCP.**
 
 The internet is debating CLI vs MCP like they're competitors. [They're not.](https://arcade.dev/blog/curl-for-mcp)
 
-Two audiences:
+Three audiences:
 
-1. **AI/LLM agents** that prefer shelling out over maintaining persistent MCP connections — better for token management, progressive tool discovery, and sharing a single pool of MCP servers across multiple agents on one machine
-2. **MCP developers** who need a fast way to discover, debug, and test their servers from the terminal
+1. **Coding agents** (Claude Code, Cursor) that prefer shelling out over maintaining persistent MCP connections — better for token management, progressive tool discovery, and sharing a single pool of MCP servers across multiple agents on one machine
+2. **Non-coding agents** that need programmatic access to MCP tools from TypeScript — remote, persistent, or isolated agents that don't have a shell
+3. **MCP developers** who need a fast way to discover, debug, and test their servers from the terminal
 
 ## Install
 
@@ -633,6 +634,51 @@ To execute tools:
   mcpx exec <server> <tool> -f params.json
 
 Always search before executing — don't assume tool names.
+```
+
+### Programmatic Usage (TypeScript SDK)
+
+For agents that don't have shell access — remote, persistent, or isolated agents running in TypeScript:
+
+```typescript
+import { McpxClient } from "@evantahler/mcpx";
+
+const client = new McpxClient();
+// or: new McpxClient({ configDir: "/path/to/.mcpx" })
+// or: new McpxClient({ servers: { mcpServers: { ... } } })
+
+// 1. Search for tools
+const results = await client.search("send a message");
+
+// 2. Inspect the tool schema
+const tool = await client.info("arcade", "Slack_SendMessage");
+
+// 3. Execute the tool
+const result = await client.exec("arcade", "Slack_SendMessage", {
+  channel: "#general",
+  message: "hello",
+});
+
+// Also available: listTools, listResources, readResource,
+// listPrompts, getPrompt, listTasks, getTask, cancelTask,
+// getServerInfo, getServerNames, validateToolInput
+
+await client.close();
+```
+
+The SDK uses the same config files as the CLI (`~/.mcpx/servers.json`, `auth.json`, `search.json`). Server management (add, remove, auth) is done via the CLI — the SDK is read-only.
+
+You can also pass server config directly, bypassing file loading entirely:
+
+```typescript
+const client = new McpxClient({
+  servers: {
+    mcpServers: {
+      local: { command: "node", args: ["server.js"] },
+      remote: { url: "https://mcp.example.com" },
+    },
+  },
+});
 ```
 
 ## Permissions (Claude Code & Cursor)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,14 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
+  "exports": {
+    ".": "./src/sdk.ts",
+    "./cli": "./src/cli.ts"
+  },
+  "main": "./src/sdk.ts",
+  "types": "./src/sdk.ts",
   "bin": {
     "mcpx": "./src/cli.ts"
   },

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,0 +1,310 @@
+import type {
+  CallToolResult,
+  GetTaskResult,
+  ListTasksResult,
+  CancelTaskResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import { ServerManager } from "./client/manager.ts";
+import type {
+  ServerManagerOptions,
+  ToolWithServer,
+  ResourceWithServer,
+  PromptWithServer,
+  ServerInfo,
+  ServerError,
+} from "./client/manager.ts";
+import { loadConfig } from "./config/loader.ts";
+import type {
+  Tool,
+  Resource,
+  Prompt,
+  ServerConfig,
+  StdioServerConfig,
+  HttpServerConfig,
+  ServersFile,
+  AuthFile,
+  AuthEntry,
+  SearchIndex,
+  Config,
+} from "./config/schemas.ts";
+import { search } from "./search/index.ts";
+import type { SearchResult, SearchOptions } from "./search/index.ts";
+import { validateToolInput } from "./validation/schema.ts";
+import type { ValidationResult, ValidationError } from "./validation/schema.ts";
+
+// Re-export types for SDK consumers
+export type {
+  // MCP SDK types
+  CallToolResult,
+  GetTaskResult,
+  ListTasksResult,
+  CancelTaskResult,
+  // Config types
+  Tool,
+  Resource,
+  Prompt,
+  ServerConfig,
+  StdioServerConfig,
+  HttpServerConfig,
+  ServersFile,
+  AuthFile,
+  AuthEntry,
+  SearchIndex,
+  Config,
+  // Manager types
+  ToolWithServer,
+  ResourceWithServer,
+  PromptWithServer,
+  ServerInfo,
+  ServerError,
+  // Search types
+  SearchResult,
+  SearchOptions,
+  // Validation types
+  ValidationResult,
+  ValidationError,
+};
+
+export interface McpxClientOptions {
+  /** Path to config directory. Defaults to ~/.mcpx or MCP_CONFIG_PATH env var. */
+  configDir?: string;
+  /** Inline server config — bypasses file loading when provided. */
+  servers?: ServersFile;
+  /** Inline auth config — bypasses file loading when provided. */
+  auth?: AuthFile;
+  /** Inline search index — bypasses file loading when provided. */
+  searchIndex?: SearchIndex;
+  /** Max concurrent server connections. Default: 5 */
+  concurrency?: number;
+  /** Request timeout in ms. Default: 1_800_000 (30 min) */
+  timeout?: number;
+  /** Max retries per operation. Default: 3 */
+  maxRetries?: number;
+  /** Enable verbose/trace logging. Default: false */
+  verbose?: boolean;
+}
+
+export class McpxClient {
+  private options: McpxClientOptions;
+  private manager: ServerManager | undefined;
+  private searchIndex: SearchIndex | undefined;
+  private connectPromise: Promise<void> | undefined;
+
+  constructor(options: McpxClientOptions = {}) {
+    this.options = options;
+  }
+
+  /** Ensure config is loaded and ServerManager is ready. Idempotent. */
+  private async ensureConnected(): Promise<ServerManager> {
+    if (this.manager) return this.manager;
+
+    if (!this.connectPromise) {
+      this.connectPromise = this.init();
+    }
+    await this.connectPromise;
+    return this.manager!;
+  }
+
+  private async init(): Promise<void> {
+    let servers: ServersFile;
+    let auth: AuthFile;
+    let configDir: string;
+    let searchIndex: SearchIndex;
+
+    if (this.options.servers) {
+      // Inline config — no file loading
+      servers = this.options.servers;
+      auth = this.options.auth ?? {};
+      configDir = this.options.configDir ?? "/tmp";
+      searchIndex = this.options.searchIndex ?? {
+        version: 1,
+        indexed_at: "",
+        embedding_model: "",
+        tools: [],
+      };
+    } else {
+      // Load from disk
+      const config = await loadConfig({ configFlag: this.options.configDir });
+      servers = config.servers;
+      auth = config.auth;
+      configDir = config.configDir;
+      searchIndex = config.searchIndex;
+    }
+
+    this.searchIndex = searchIndex;
+
+    const managerOpts: ServerManagerOptions = {
+      servers,
+      configDir,
+      auth,
+      concurrency: this.options.concurrency,
+      verbose: this.options.verbose,
+      timeout: this.options.timeout,
+      maxRetries: this.options.maxRetries,
+      logLevel: "emergency", // suppress server log messages from writing to stderr
+      noInteractive: true, // agents can't fill elicitation forms
+    };
+
+    this.manager = new ServerManager(managerOpts);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core workflow: search → info → exec
+  // ---------------------------------------------------------------------------
+
+  /** Search for tools by keyword and/or semantic similarity. Requires a pre-built index (run `mcpx index` via CLI). */
+  async search(query: string, options?: SearchOptions): Promise<SearchResult[]> {
+    await this.ensureConnected();
+    if (!this.searchIndex || this.searchIndex.tools.length === 0) {
+      throw new Error("No search index found. Build one with: mcpx index");
+    }
+    return search(query, this.searchIndex, options);
+  }
+
+  /** Get a tool's schema (name, description, inputSchema). */
+  async info(server: string, tool: string): Promise<Tool | undefined> {
+    const manager = await this.ensureConnected();
+    return manager.getToolSchema(server, tool);
+  }
+
+  /** Execute a tool and return the result. */
+  async exec(
+    server: string,
+    tool: string,
+    args?: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    const manager = await this.ensureConnected();
+    return manager.callTool(server, tool, args ?? {}) as Promise<CallToolResult>;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tools
+  // ---------------------------------------------------------------------------
+
+  /** List tools, optionally filtered to a single server. */
+  async listTools(server?: string): Promise<ToolWithServer[]> {
+    const manager = await this.ensureConnected();
+    if (server) {
+      const tools = await manager.listTools(server);
+      return tools.map((tool) => ({ server, tool }));
+    }
+    const { tools } = await manager.getAllTools();
+    return tools;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Validation
+  // ---------------------------------------------------------------------------
+
+  /** Validate arguments against a tool's inputSchema. */
+  async validateToolInput(
+    server: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<ValidationResult> {
+    const tool = await this.info(server, toolName);
+    if (!tool) {
+      return { valid: false, errors: [{ path: "(root)", message: `Tool not found: ${toolName}` }] };
+    }
+    return validateToolInput(server, tool, args);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Resources
+  // ---------------------------------------------------------------------------
+
+  /** List resources, optionally filtered to a single server. */
+  async listResources(server?: string): Promise<ResourceWithServer[]> {
+    const manager = await this.ensureConnected();
+    if (server) {
+      const resources = await manager.listResources(server);
+      return resources.map((resource) => ({ server, resource }));
+    }
+    const { resources } = await manager.getAllResources();
+    return resources;
+  }
+
+  /** Read a specific resource by URI. */
+  async readResource(server: string, uri: string): Promise<unknown> {
+    const manager = await this.ensureConnected();
+    return manager.readResource(server, uri);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Prompts
+  // ---------------------------------------------------------------------------
+
+  /** List prompts, optionally filtered to a single server. */
+  async listPrompts(server?: string): Promise<PromptWithServer[]> {
+    const manager = await this.ensureConnected();
+    if (server) {
+      const prompts = await manager.listPrompts(server);
+      return prompts.map((prompt) => ({ server, prompt }));
+    }
+    const { prompts } = await manager.getAllPrompts();
+    return prompts;
+  }
+
+  /** Get a specific prompt by name, optionally with arguments. */
+  async getPrompt(server: string, name: string, args?: Record<string, string>): Promise<unknown> {
+    const manager = await this.ensureConnected();
+    return manager.getPrompt(server, name, args);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tasks
+  // ---------------------------------------------------------------------------
+
+  /** List tasks on a server. */
+  async listTasks(server: string, cursor?: string): Promise<ListTasksResult> {
+    const manager = await this.ensureConnected();
+    return manager.listTasks(server, cursor);
+  }
+
+  /** Get the status of a task. */
+  async getTask(server: string, taskId: string): Promise<GetTaskResult> {
+    const manager = await this.ensureConnected();
+    return manager.getTask(server, taskId);
+  }
+
+  /** Retrieve the result of a completed task. */
+  async getTaskResult(server: string, taskId: string): Promise<CallToolResult> {
+    const manager = await this.ensureConnected();
+    return manager.getTaskResult(server, taskId);
+  }
+
+  /** Cancel a running task. */
+  async cancelTask(server: string, taskId: string): Promise<CancelTaskResult> {
+    const manager = await this.ensureConnected();
+    return manager.cancelTask(server, taskId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Server info
+  // ---------------------------------------------------------------------------
+
+  /** Get server info (version, capabilities, instructions). */
+  async getServerInfo(server: string): Promise<ServerInfo> {
+    const manager = await this.ensureConnected();
+    return manager.getServerInfo(server);
+  }
+
+  /** Get all configured server names. */
+  async getServerNames(): Promise<string[]> {
+    const manager = await this.ensureConnected();
+    return manager.getServerNames();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /** Disconnect all servers and clean up. */
+  async close(): Promise<void> {
+    if (this.manager) {
+      await this.manager.close();
+      this.manager = undefined;
+      this.connectPromise = undefined;
+    }
+  }
+}

--- a/test/sdk/client.test.ts
+++ b/test/sdk/client.test.ts
@@ -1,0 +1,441 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { McpxClient } from "../../src/sdk.ts";
+import type { ServersFile, SearchIndex } from "../../src/sdk.ts";
+
+const MOCK_SERVER = join(import.meta.dir, "../fixtures/mock-server.ts");
+
+function makeInlineServers(overrides?: Record<string, unknown>): ServersFile {
+  return {
+    mcpServers: {
+      mock: {
+        command: "bun",
+        args: ["run", MOCK_SERVER],
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe("McpxClient", () => {
+  let client: McpxClient;
+
+  afterEach(async () => {
+    if (client) await client.close();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  test("lazy connects on first method call", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    // No explicit connect — listTools triggers it
+    const tools = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+  });
+
+  test("close is safe to call multiple times", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    await client.listTools();
+    await client.close();
+    await client.close(); // should not throw
+  });
+
+  test("can reconnect after close", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    await client.listTools();
+    await client.close();
+    // Should reconnect on next call
+    const tools = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tools
+  // ---------------------------------------------------------------------------
+
+  test("listTools returns all tools with server names", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const tools = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+    expect(tools[0]!.server).toBe("mock");
+    expect(tools[0]!.tool.name).toBeDefined();
+    const names = tools.map((t) => t.tool.name);
+    expect(names).toContain("echo");
+    expect(names).toContain("add");
+  });
+
+  test("listTools with server filter", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const tools = await client.listTools("mock");
+    expect(tools.length).toBeGreaterThan(0);
+    expect(tools.every((t) => t.server === "mock")).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Info
+  // ---------------------------------------------------------------------------
+
+  test("info returns tool schema", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const tool = await client.info("mock", "echo");
+    expect(tool).toBeDefined();
+    expect(tool!.name).toBe("echo");
+    expect(tool!.inputSchema.properties).toHaveProperty("message");
+  });
+
+  test("info returns undefined for unknown tool", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const tool = await client.info("mock", "nonexistent");
+    expect(tool).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Exec
+  // ---------------------------------------------------------------------------
+
+  test("exec calls a tool and returns result", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = await client.exec("mock", "echo", { message: "hello SDK" });
+    expect(result.content).toBeDefined();
+    const text = (result.content as { type: string; text: string }[])[0]!;
+    expect(text.text).toBe("hello SDK");
+  });
+
+  test("exec with add tool", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = await client.exec("mock", "add", { a: 10, b: 20 });
+    const text = (result.content as { type: string; text: string }[])[0]!;
+    expect(text.text).toBe("30");
+  });
+
+  test("exec with no args", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = await client.exec("mock", "noop");
+    const text = (result.content as { type: string; text: string }[])[0]!;
+    expect(text.text).toBe("ok");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Validation
+  // ---------------------------------------------------------------------------
+
+  test("validateToolInput succeeds with valid args", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = await client.validateToolInput("mock", "echo", { message: "hi" });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("validateToolInput fails with wrong type", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = await client.validateToolInput("mock", "add", {
+      a: "not a number",
+      b: "also not a number",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]!.message).toContain("number");
+  });
+
+  test("validateToolInput fails with wrong property name", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = await client.validateToolInput("mock", "echo", {
+      wrong_name: "hello",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    // Should report missing required field "message"
+    expect(result.errors.some((e) => e.message.includes("message"))).toBe(true);
+  });
+
+  test("validateToolInput fails with missing required field", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = await client.validateToolInput("mock", "echo", {});
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test("validateToolInput returns error for unknown tool", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = await client.validateToolInput("mock", "nonexistent", {});
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]!.message).toContain("Tool not found");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Search
+  // ---------------------------------------------------------------------------
+
+  test("search throws when no index is available", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    await expect(client.search("something")).rejects.toThrow("No search index found");
+  });
+
+  test("keyword search finds tools by name keywords", async () => {
+    const searchIndex: SearchIndex = {
+      version: 1,
+      indexed_at: new Date().toISOString(),
+      embedding_model: "test",
+      tools: [
+        {
+          server: "arcade",
+          tool: "Slack_SendMessage",
+          description: "Send a message to a Slack channel",
+          scenarios: ["send a slack message"],
+          keywords: ["slack", "send", "message"],
+          embedding: [],
+          input_schema: { type: "object" },
+        },
+        {
+          server: "arcade",
+          tool: "Gmail_SendEmail",
+          description: "Send an email via Gmail",
+          scenarios: ["send an email"],
+          keywords: ["gmail", "send", "email"],
+          embedding: [],
+          input_schema: { type: "object" },
+        },
+        {
+          server: "github",
+          tool: "search_repositories",
+          description: "Search for repositories on GitHub",
+          scenarios: ["search repos"],
+          keywords: ["github", "search", "repositories"],
+          embedding: [],
+          input_schema: { type: "object" },
+        },
+      ],
+    };
+
+    client = new McpxClient({ servers: makeInlineServers(), searchIndex });
+
+    // "slack" should match only the Slack tool
+    const slackResults = await client.search("slack", { keywordOnly: true });
+    expect(slackResults.length).toBe(1);
+    expect(slackResults[0]!.tool).toBe("Slack_SendMessage");
+
+    // "send" should match both Slack and Gmail
+    const sendResults = await client.search("send", { keywordOnly: true });
+    expect(sendResults.length).toBe(2);
+    const sendTools = sendResults.map((r) => r.tool).sort();
+    expect(sendTools).toEqual(["Gmail_SendEmail", "Slack_SendMessage"]);
+
+    // "github" should match the GitHub tool
+    const githubResults = await client.search("github", { keywordOnly: true });
+    expect(githubResults.length).toBe(1);
+    expect(githubResults[0]!.tool).toBe("search_repositories");
+  });
+
+  test("keyword search returns empty for unrelated query", async () => {
+    const searchIndex: SearchIndex = {
+      version: 1,
+      indexed_at: new Date().toISOString(),
+      embedding_model: "test",
+      tools: [
+        {
+          server: "arcade",
+          tool: "Slack_SendMessage",
+          description: "Send a message to a Slack channel",
+          scenarios: ["send a slack message"],
+          keywords: ["slack", "send", "message"],
+          embedding: [],
+          input_schema: { type: "object" },
+        },
+      ],
+    };
+
+    client = new McpxClient({ servers: makeInlineServers(), searchIndex });
+    const results = await client.search("database migration", { keywordOnly: true });
+    expect(results.length).toBe(0);
+  });
+
+  // Synthetic embeddings with known cosine similarity properties.
+  // "messaging" cluster: Slack and Gmail share a similar direction.
+  // "code" cluster: GitHub points in a different direction.
+  // A "messaging query" vector is close to the messaging cluster.
+  // A "code query" vector is close to the code cluster.
+  const MESSAGING_DIR = [0.9, 0.3, 0.1, 0.0]; // Slack & Gmail neighborhood
+  const CODE_DIR = [0.1, 0.1, 0.9, 0.3]; // GitHub neighborhood
+
+  function makeSemanticIndex(): SearchIndex {
+    return {
+      version: 1,
+      indexed_at: new Date().toISOString(),
+      embedding_model: "synthetic-test",
+      tools: [
+        {
+          server: "arcade",
+          tool: "Slack_SendMessage",
+          description: "Send a message to a Slack channel",
+          scenarios: ["send a slack message"],
+          keywords: ["slack", "send", "message"],
+          embedding: [0.9, 0.35, 0.1, 0.0], // close to MESSAGING_DIR
+          input_schema: { type: "object" },
+        },
+        {
+          server: "arcade",
+          tool: "Gmail_SendEmail",
+          description: "Send an email via Gmail",
+          scenarios: ["send an email"],
+          keywords: ["gmail", "send", "email"],
+          embedding: [0.85, 0.25, 0.15, 0.05], // close to MESSAGING_DIR
+          input_schema: { type: "object" },
+        },
+        {
+          server: "github",
+          tool: "search_repositories",
+          description: "Search for repositories on GitHub",
+          scenarios: ["search repos"],
+          keywords: ["github", "search", "repositories"],
+          embedding: [0.1, 0.15, 0.85, 0.35], // close to CODE_DIR
+          input_schema: { type: "object" },
+        },
+      ],
+    };
+  }
+
+  test("semantic search ranks messaging tools higher for messaging query", async () => {
+    // Mock the embedder to return our synthetic "messaging" query vector
+    const { semanticSearch: origSemantic } = await import("../../src/search/semantic.ts");
+    const { mock } = await import("bun:test");
+    const mod = await import("../../src/search/semantic.ts");
+    mock.module("../../src/search/semantic.ts", () => ({
+      ...mod,
+      generateEmbedding: async () => MESSAGING_DIR,
+      cosineSimilarity: mod.cosineSimilarity,
+      semanticSearch: mod.semanticSearch,
+    }));
+
+    const searchIndex = makeSemanticIndex();
+    client = new McpxClient({ servers: makeInlineServers(), searchIndex });
+    const results = await client.search("post a chat message", { semanticOnly: true });
+
+    expect(results.length).toBe(3);
+    // Slack and Gmail (messaging) should rank above GitHub (code)
+    const slackIdx = results.findIndex((r) => r.tool === "Slack_SendMessage");
+    const githubIdx = results.findIndex((r) => r.tool === "search_repositories");
+    expect(slackIdx).toBeLessThan(githubIdx);
+
+    mock.restore();
+  });
+
+  test("semantic search ranks GitHub tool higher for code query", async () => {
+    const { mock } = await import("bun:test");
+    const mod = await import("../../src/search/semantic.ts");
+    mock.module("../../src/search/semantic.ts", () => ({
+      ...mod,
+      generateEmbedding: async () => CODE_DIR,
+      cosineSimilarity: mod.cosineSimilarity,
+      semanticSearch: mod.semanticSearch,
+    }));
+
+    const searchIndex = makeSemanticIndex();
+    client = new McpxClient({ servers: makeInlineServers(), searchIndex });
+    const results = await client.search("find open source code projects", {
+      semanticOnly: true,
+    });
+
+    expect(results.length).toBe(3);
+    // GitHub (code) should rank first for a code query
+    expect(results[0]!.tool).toBe("search_repositories");
+
+    mock.restore();
+  });
+
+  test("combined search merges keyword and semantic results", async () => {
+    const { mock } = await import("bun:test");
+    const mod = await import("../../src/search/semantic.ts");
+    mock.module("../../src/search/semantic.ts", () => ({
+      ...mod,
+      generateEmbedding: async () => MESSAGING_DIR,
+      cosineSimilarity: mod.cosineSimilarity,
+      semanticSearch: mod.semanticSearch,
+    }));
+
+    const searchIndex = makeSemanticIndex();
+    client = new McpxClient({ servers: makeInlineServers(), searchIndex });
+    // "slack" matches keyword for Slack, semantic also contributes
+    const results = await client.search("slack");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]!.tool).toBe("Slack_SendMessage");
+    expect(results[0]!.matchType).toBe("both");
+
+    mock.restore();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Resources
+  // ---------------------------------------------------------------------------
+
+  test("listResources returns resources", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const resources = await client.listResources();
+    expect(resources.length).toBeGreaterThan(0);
+    expect(resources[0]!.server).toBe("mock");
+    expect(resources[0]!.resource.uri).toBeDefined();
+  });
+
+  test("listResources with server filter", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const resources = await client.listResources("mock");
+    expect(resources.length).toBeGreaterThan(0);
+    expect(resources.every((r) => r.server === "mock")).toBe(true);
+  });
+
+  test("readResource returns content", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = (await client.readResource("mock", "file:///hello.txt")) as {
+      contents: { text: string }[];
+    };
+    expect(result.contents[0]!.text).toBe("Hello, World!");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Prompts
+  // ---------------------------------------------------------------------------
+
+  test("listPrompts returns prompts", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const prompts = await client.listPrompts();
+    expect(prompts.length).toBeGreaterThan(0);
+    const names = prompts.map((p) => p.prompt.name);
+    expect(names).toContain("greet");
+    expect(names).toContain("summarize");
+  });
+
+  test("getPrompt returns prompt messages", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const result = (await client.getPrompt("mock", "greet", { name: "SDK" })) as {
+      messages: { content: { text: string } }[];
+    };
+    expect(result.messages[0]!.content.text).toBe("Hello, SDK!");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Server info
+  // ---------------------------------------------------------------------------
+
+  test("getServerNames returns configured servers", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const names = await client.getServerNames();
+    expect(names).toEqual(["mock"]);
+  });
+
+  test("getServerInfo returns server metadata", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    const info = await client.getServerInfo("mock");
+    expect(info.version?.name).toBe("mock-server");
+    expect(info.capabilities?.tools).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  test("throws on unknown server", async () => {
+    client = new McpxClient({ servers: makeInlineServers() });
+    await expect(client.exec("nonexistent", "echo", {})).rejects.toThrow("Unknown server");
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `McpxClient` — a TypeScript class that lets remote, persistent, or isolated agents use MCP tools programmatically without shell access. The SDK exposes the same search → inspect → exec workflow as the CLI, plus resources, prompts, tasks, validation, and server info.

- **New `src/sdk.ts`**: `McpxClient` class wrapping `ServerManager` + `loadConfig` + `search()` with lazy connect, `noInteractive: true`, and suppressed server log output
- **New `test/sdk/client.test.ts`**: 29 integration tests covering tools, exec, validation (wrong types/names), keyword search, semantic search (synthetic embeddings), resources, prompts, server info, and error handling
- **`package.json`**: Version bump to 0.18.0, added `exports`/`main`/`types` fields so consumers can `import { McpxClient } from "@evantahler/mcpx"`
- **`README.md`**: Updated audiences (now three), added "Programmatic Usage (TypeScript SDK)" section with inline config examples
- **`.claude/skills/mcpx.md` + `.cursor/rules/mcpx.mdc`**: Added SDK usage section

Server management (add, remove, auth, allow/deny) stays CLI-only — a nice security boundary where humans control which servers are configured and agents can only consume them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)