### PR TITLE
Upgrade GitHub Actions to Node 24 (checkout@v5, setup-node@v5)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,7 +17,7 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get version from package.json
         id: version
@@ -42,7 +42,7 @@ jobs:
     if: needs.check-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Create release
         run: |
           gh release create "${{ needs.check-version.outputs.tag }}" \
@@ -56,7 +56,7 @@ jobs:
     if: needs.check-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -72,11 +72,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22.14.0"
       - run: npm install -g npm@11.5.1
@@ -103,7 +103,7 @@ jobs:
           - target: bun-windows-arm64
             artifact: mcpx-windows-arm64.exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -20,11 +20,11 @@ jobs:
   test-upgrade:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
       - run: bun install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 → v5 and `actions/setup-node` from v4 → v5 across both CI and auto-release workflows
- Node.js 20 is deprecated for GitHub Actions runners (enforced June 2026, removed September 2026); v5 of these actions uses Node 24
- Patch version bump to 0.18.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)