### PR TITLE
Add colored help text using Commander's style hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "exports": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { program } from "commander";
+import { bold, cyan, yellow, dim, green } from "ansis";
 import { registerListCommand } from "./commands/list.ts";
 import { registerInfoCommand } from "./commands/info.ts";
 import { registerSearchCommand } from "./commands/search.ts";
@@ -39,6 +40,15 @@ program
     "minimum server log level (debug|info|notice|warning|error|critical|alert|emergency)",
     "warning",
   );
+
+program.configureHelp({
+  styleTitle: (str) => bold(str),
+  styleCommandText: (str) => cyan(str),
+  styleSubcommandText: (str) => cyan(str),
+  styleOptionText: (str) => yellow(str),
+  styleArgumentText: (str) => green(str),
+  styleDescriptionText: (str) => dim(str),
+});
 
 registerListCommand(program);
 registerInfoCommand(program);


### PR DESCRIPTION
## Summary
- Adds color to all `--help` output using Commander v14's built-in `configureHelp()` style hooks and `ansis` (already a dependency)
- **Bold** for section headings (Usage:, Options:, Commands:)
- **Cyan** for command/subcommand names
- **Yellow** for option flags
- **Green** for arguments
- **Dim** for descriptions
- Colors auto-strip in non-TTY (piped) contexts

## Test plan
- [x] `bun run dev -- --help` shows colored output
- [x] `bun run dev -- exec --help` shows colored subcommand output
- [x] All 345 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)