### PR TITLE
Fix type errors in source for strict-mode consumers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ mcpx — A CLI for MCP servers. "curl for MCP."
 
 - `bun run dev` — Run in development mode
 - `bun test` — Run tests
-- `bun lint` — Check formatting (prettier)
+- `bun lint` — Check formatting and types
 - `bun format` — Auto-fix formatting
 - `bun run build` — Build single binary
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@types/picomatch": "^4.0.2",
         "ajv": "^8.18.0",
         "ansis": "^4.2.0",
         "commander": "^14.0.3",
@@ -15,8 +16,8 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@types/picomatch": "^4.0.2",
         "prettier": "^3.8.1",
+        "typescript": "^5",
       },
       "peerDependencies": {
         "typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evantahler/mcpx",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "A command-line interface for MCP servers. curl for MCP.",
   "type": "module",
   "exports": {
@@ -23,7 +23,7 @@
     "dev": "bun run src/cli.ts",
     "test": "bun test",
     "test:e2e": "bun test test/integration/remote-server.test.ts",
-    "lint": "prettier --check .",
+    "lint": "prettier --check . && tsc --noEmit",
     "format": "prettier --write .",
     "build": "bun build --compile --minify --sourcemap ./src/cli.ts --outfile dist/mcpx"
   },
@@ -51,12 +51,13 @@
     "ansis": "^4.2.0",
     "commander": "^14.0.3",
     "nanospinner": "^1.2.2",
-    "picomatch": "^4.0.3"
+    "picomatch": "^4.0.3",
+    "@types/picomatch": "^4.0.2"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/picomatch": "^4.0.2",
-    "prettier": "^3.8.1"
+    "prettier": "^3.8.1",
+    "typescript": "^5"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ const knownCommands = new Set(program.commands.map((c) => c.name()));
 const cliArgs = process.argv.slice(2);
 let firstCommand: string | undefined;
 for (let i = 0; i < cliArgs.length; i++) {
-  const a = cliArgs[i];
+  const a = cliArgs[i]!;
   if (
     a === "-c" ||
     a === "--config" ||

--- a/src/client/debug-fetch.ts
+++ b/src/client/debug-fetch.ts
@@ -38,7 +38,7 @@ function log(line: string) {
 
 function logHeaders(
   prefix: string,
-  headers: HeadersInit | Headers | undefined,
+  headers: RequestInit["headers"],
   fmt: (s: string) => string,
   showSecrets: boolean,
 ) {
@@ -50,11 +50,11 @@ function logHeaders(
   if (headers instanceof Headers) {
     headers.forEach((value, key) => log(format(key, value)));
   } else if (Array.isArray(headers)) {
-    for (const [key, value] of headers) {
-      log(format(key, value));
+    for (const pair of headers) {
+      log(format(String(pair[0]), String(pair[1])));
     }
   } else {
-    for (const [key, value] of Object.entries(headers)) {
+    for (const [key, value] of Object.entries(headers as Record<string, string>)) {
       log(format(key, value));
     }
   }

--- a/src/client/oauth.ts
+++ b/src/client/oauth.ts
@@ -301,7 +301,7 @@ export async function runOAuthFlow(serverUrl: string, provider: McpOAuthProvider
 
   const { server, authCodePromise } = startCallbackServer();
   try {
-    provider.setCallbackPort(server.port);
+    provider.setCallbackPort(server.port!);
 
     const result = await auth(provider, { serverUrl });
     if (result === "REDIRECT") {

--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -5,7 +5,7 @@ export function createStdioTransport(config: StdioServerConfig): StdioClientTran
   return new StdioClientTransport({
     command: config.command,
     args: config.args,
-    env: config.env ? { ...process.env, ...config.env } : undefined,
+    env: config.env ? ({ ...process.env, ...config.env } as Record<string, string>) : undefined,
     cwd: config.cwd,
     stderr: "pipe",
   });

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -156,7 +156,7 @@ function buildStdioConfig(options: {
     config.cwd = options.cwd;
   }
 
-  return config as ServerConfig;
+  return config as unknown as ServerConfig;
 }
 
 function buildHttpConfig(options: { url?: string; header?: string[] }): ServerConfig {
@@ -175,5 +175,5 @@ function buildHttpConfig(options: { url?: string; header?: string[] }): ServerCo
     config.headers = headers;
   }
 
-  return config as ServerConfig;
+  return config as unknown as ServerConfig;
 }

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -166,7 +166,7 @@ export function formatServerOverview(overview: ServerOverview, options: FormatOp
         const maxName = Math.max(...overview.tools.map((t) => t.name.length));
         const termWidth = getTerminalWidth();
         for (let i = 0; i < overview.tools.length; i++) {
-          const t = overview.tools[i];
+          const t = overview.tools[i]!;
           if (i > 0) lines.push("");
           const name = `  ${bold(t.name.padEnd(maxName))}`;
           if (t.description) {
@@ -622,7 +622,7 @@ export function jsonToMarkdown(value: unknown, depth: number = 1, skipKey?: stri
 
 /** Render a markdown string to ANSI-styled terminal output using Bun's built-in renderer */
 export function renderMarkdownToAnsi(input: string): string {
-  const result = Bun.markdown.ansi(input);
+  const result = (Bun as any).markdown.ansi(input) as string;
   const restored = restoreUrlPlaceholders(result);
   resetUrlPlaceholders();
   return restored;

--- a/src/search/semantic.ts
+++ b/src/search/semantic.ts
@@ -53,7 +53,7 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 export async function semanticSearch(
   query: string,
   tools: IndexedTool[],
-  topK = DEFAULTS.SEARCH_TOP_K,
+  topK: number = DEFAULTS.SEARCH_TOP_K,
 ): Promise<SemanticMatch[]> {
   // Only search tools that have embeddings
   const withEmbeddings = tools.filter((t) => t.embedding.length > 0);

--- a/test/client/trace.test.ts
+++ b/test/client/trace.test.ts
@@ -169,7 +169,7 @@ describe("wrapTransportWithTrace", () => {
     } as unknown as JSONRPCMessage);
 
     const lines = stderr.output.trim().split("\n");
-    const incomingLine = JSON.parse(lines[lines.length - 1]);
+    const incomingLine = JSON.parse(lines[lines.length - 1]!);
     expect(incomingLine.trace).toBe("incoming");
     expect(incomingLine.server).toBe("myserver");
     expect(incomingLine.request_method).toBe("ping");

--- a/test/fixtures/mock-http-server.ts
+++ b/test/fixtures/mock-http-server.ts
@@ -171,7 +171,12 @@ const server = Bun.serve({
     }
 
     if (req.method === "POST") {
-      const body = await req.json();
+      const body = (await req.json()) as {
+        jsonrpc: string;
+        id?: number;
+        method: string;
+        params?: unknown;
+      };
       const response = handleJsonRpc(body);
 
       // Assign session ID on initialize

--- a/test/integration/remote-server.test.ts
+++ b/test/integration/remote-server.test.ts
@@ -46,7 +46,7 @@ beforeAll(async () => {
   });
 
   // Read the server URL from stdout (first line)
-  const reader = serverProc.stdout.getReader();
+  const reader = (serverProc.stdout as ReadableStream<Uint8Array>).getReader();
   const { value } = await reader.read();
   reader.releaseLock();
   const serverUrl = new TextDecoder().decode(value).trim();

--- a/test/integration/stdio-server.test.ts
+++ b/test/integration/stdio-server.test.ts
@@ -94,7 +94,7 @@ describe("stdio MCP server integration", () => {
   });
 
   test("calls add tool with numeric arguments", async () => {
-    const result = await runAndParse<{ content: { type: string; text: string }[] }>(
+    const result = await runAndParse<{ content: { type: string; text: unknown }[] }>(
       "exec",
       "mock",
       "add",

--- a/test/output/formatter.test.ts
+++ b/test/output/formatter.test.ts
@@ -309,7 +309,7 @@ describe("wrapDescription", () => {
     expect(lines.length).toBeGreaterThan(1);
     // Continuation lines should start with 10 spaces
     for (let i = 1; i < lines.length; i++) {
-      expect(lines[i].startsWith(" ".repeat(10))).toBe(true);
+      expect(lines[i]!.startsWith(" ".repeat(10))).toBe(true);
     }
   });
 


### PR DESCRIPTION
## Summary
- Fix all `tsc --noEmit` errors so consumers importing `@evantahler/mcpx` with strict TypeScript no longer get build failures from raw `.ts` source
- Add `tsc --noEmit` to the `bun lint` script so type errors are caught in CI
- Move `@types/picomatch` to dependencies and `typescript` to devDependencies

## Test plan
- [x] `bun lint` passes (prettier + tsc --noEmit)
- [x] `bun test` passes (345 tests)
- [ ] Verify a strict-mode consumer project can import `@evantahler/mcpx` without type errors

Closes https://github.com/evantahler/mcpx/issues/63

🤖 Generated with [Claude Code](https://claude.com/claude-code)