### PR TITLE
Fix security vulnerabilities: shell injection, validation bypass, credential exposure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.18.5",
+	"version": "0.18.6",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/client/browser.ts
+++ b/src/client/browser.ts
@@ -1,20 +1,41 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 
 /**
  * Open a URL in the default browser (macOS/Windows/Linux).
  * Falls back to printing the URL to stderr if no browser is available
  * (e.g., headless servers, Docker containers).
+ *
+ * Uses execFile (not exec) to avoid shell injection via malicious URLs.
  */
 export function openBrowser(url: string): Promise<void> {
-	const cmd =
-		process.platform === "darwin"
-			? `open "${url}"`
-			: process.platform === "win32"
-				? `start "${url}"`
-				: `xdg-open "${url}"`;
+	// Validate URL scheme to prevent non-HTTP protocols
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+			process.stderr.write(`Refusing to open non-HTTP URL: ${url}\n`);
+			return Promise.resolve();
+		}
+	} catch {
+		process.stderr.write(`Invalid URL: ${url}\n`);
+		return Promise.resolve();
+	}
+
+	let cmd: string;
+	let args: string[];
+
+	if (process.platform === "darwin") {
+		cmd = "open";
+		args = [url];
+	} else if (process.platform === "win32") {
+		cmd = "cmd";
+		args = ["/c", "start", "", url];
+	} else {
+		cmd = "xdg-open";
+		args = [url];
+	}
 
 	return new Promise((resolve) => {
-		exec(cmd, (err) => {
+		execFile(cmd, args, (err) => {
 			if (err) {
 				process.stderr.write(`Could not open browser. Please visit:\n  ${url}\n`);
 			}

--- a/src/client/debug-fetch.ts
+++ b/src/client/debug-fetch.ts
@@ -68,11 +68,22 @@ function logBody(body: string, fmt: (s: string) => string) {
 	}
 }
 
+const SENSITIVE_HEADERS = new Set([
+	"authorization",
+	"cookie",
+	"set-cookie",
+	"proxy-authorization",
+	"x-api-key",
+	"api-key",
+	"x-auth-token",
+	"x-token",
+	"token",
+]);
+
 export function maskSensitive(key: string, value: string): string {
-	const lower = key.toLowerCase();
-	if (lower === "authorization" || lower === "cookie" || lower === "set-cookie") {
-		if (value.length <= 12) return value;
-		return `${value.slice(0, 12)}...`;
+	if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
+		if (value.length <= 6) return "***";
+		return `${value.slice(0, 4)}...`;
 	}
 	return value;
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,3 +1,4 @@
+import { chmod } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { DEFAULT_CONFIG_DIR, ENV } from "../constants.ts";
 import { interpolateEnv } from "./env.ts";
@@ -63,6 +64,7 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Confi
 		const cwd = process.cwd();
 		if (await hasServersFile(cwd)) {
 			configDir = cwd;
+			process.stderr.write(`Note: using servers.json from current directory (${cwd})\n`);
 		}
 	}
 
@@ -109,9 +111,10 @@ async function saveJsonFile(configDir: string, filename: string, data: unknown):
 	await Bun.write(join(configDir, filename), `${JSON.stringify(data, null, 2)}\n`);
 }
 
-/** Save auth.json to the config directory */
+/** Save auth.json to the config directory with restrictive permissions */
 export async function saveAuth(configDir: string, auth: AuthFile): Promise<void> {
-	return saveJsonFile(configDir, "auth.json", auth);
+	await saveJsonFile(configDir, "auth.json", auth);
+	await chmod(join(configDir, "auth.json"), 0o600).catch(() => {});
 }
 
 /** Load search.json from the config directory */

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -619,20 +619,23 @@ export function renderMarkdownToAnsi(input: string): string {
 	return restored;
 }
 
+const MAX_NESTED_JSON_DEPTH = 10;
+
 /** Recursively parse JSON strings inside MCP content blocks */
-function parseNestedJson(value: unknown): unknown {
+function parseNestedJson(value: unknown, depth = 0): unknown {
+	if (depth > MAX_NESTED_JSON_DEPTH) return value;
 	if (typeof value === "string") {
 		try {
-			return parseNestedJson(JSON.parse(value));
+			return parseNestedJson(JSON.parse(value), depth + 1);
 		} catch {
 			return value;
 		}
 	}
 	if (Array.isArray(value)) {
-		return value.map(parseNestedJson);
+		return value.map((v) => parseNestedJson(v, depth + 1));
 	}
 	if (typeof value === "object" && value !== null) {
-		return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, parseNestedJson(v)]));
+		return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, parseNestedJson(v, depth + 1)]));
 	}
 	return value;
 }

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -28,8 +28,9 @@ function validateWithSchema(
 		try {
 			validate = ajv.compile(schema);
 			validatorCache.set(cacheKey, validate);
-		} catch {
-			return { valid: true, errors: [] };
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : "unknown error";
+			return { valid: false, errors: [{ path: "(schema)", message: `schema compilation failed: ${msg}` }] };
 		}
 	}
 

--- a/test/client/debug-fetch.test.ts
+++ b/test/client/debug-fetch.test.ts
@@ -4,23 +4,53 @@ import { createDebugFetch, maskSensitive } from "../../src/client/debug-fetch.ts
 describe("maskSensitive", () => {
 	test("masks Authorization header values", () => {
 		const result = maskSensitive("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.test");
-		expect(result).toBe("Bearer eyJhb...");
-		expect(result).not.toContain("test");
+		expect(result).toBe("Bear...");
+		expect(result).not.toContain("eyJ");
 	});
 
 	test("masks Cookie header values", () => {
 		const result = maskSensitive("Cookie", "session=abc123def456ghi789");
-		expect(result).toBe("session=abc1...");
+		expect(result).toBe("sess...");
 	});
 
 	test("masks Set-Cookie header values", () => {
 		const result = maskSensitive("Set-Cookie", "session=abc123def456ghi789");
-		expect(result).toBe("session=abc1...");
+		expect(result).toBe("sess...");
 	});
 
-	test("does not mask short values", () => {
-		const result = maskSensitive("Authorization", "Bearer tok");
-		expect(result).toBe("Bearer tok");
+	test("fully masks short sensitive values", () => {
+		const result = maskSensitive("Authorization", "short");
+		expect(result).toBe("***");
+	});
+
+	test("masks x-api-key header", () => {
+		const result = maskSensitive("X-Api-Key", "sk-1234567890abcdef");
+		expect(result).toBe("sk-1...");
+	});
+
+	test("masks api-key header", () => {
+		const result = maskSensitive("Api-Key", "supersecretkey123");
+		expect(result).toBe("supe...");
+	});
+
+	test("masks proxy-authorization header", () => {
+		const result = maskSensitive("Proxy-Authorization", "Basic dXNlcjpwYXNz");
+		expect(result).toBe("Basi...");
+	});
+
+	test("masks x-auth-token header", () => {
+		const result = maskSensitive("X-Auth-Token", "tok_abc123xyz");
+		expect(result).toBe("tok_...");
+	});
+
+	test("masks x-token header", () => {
+		const result = maskSensitive("X-Token", "mytoken123");
+		expect(result).toBe("myto...");
+	});
+
+	test("masks token header", () => {
+		const result = maskSensitive("Token", "abcdefghij");
+		expect(result).toBe("abcd...");
 	});
 
 	test("passes non-sensitive headers through unchanged", () => {

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig, saveAuth, saveSearchIndex } from "../../src/config/loader.ts";
@@ -143,6 +143,18 @@ describe("saveAuth / saveSearchIndex", () => {
 
 		const raw = await Bun.file(join(tmpDir, "auth.json")).json();
 		expect(raw.test.tokens.access_token).toBe("abc");
+	});
+
+	test("sets restrictive permissions on auth.json", async () => {
+		await saveAuth(tmpDir, {
+			test: {
+				tokens: { access_token: "secret", token_type: "bearer" },
+			},
+		});
+
+		const info = await stat(join(tmpDir, "auth.json"));
+		const mode = info.mode & 0o777;
+		expect(mode).toBe(0o600);
 	});
 
 	test("saves and reloads search.json", async () => {

--- a/test/validation/schema.test.ts
+++ b/test/validation/schema.test.ts
@@ -99,6 +99,23 @@ describe("validateToolInput", () => {
 		expect(result.errors.length).toBe(2);
 	});
 
+	test("returns invalid when schema compilation fails", () => {
+		const tool = makeTool("bad_schema", {
+			type: "object",
+			properties: { x: { type: "string" } },
+			// Invalid: $ref with other keywords in strict AJV contexts can fail,
+			// but a more reliable way to trigger compile failure is an invalid type
+			patternProperties: { "^x": { type: "invalid_type_that_breaks" } },
+			additionalProperties: { $ref: "#/definitions/nonexistent" },
+		});
+		const result = validateToolInput("bad_schema_server", tool, { x: "hello" });
+		// Should not silently pass — must report as invalid
+		expect(result.valid).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+		expect(result.errors[0]?.path).toBe("(schema)");
+		expect(result.errors[0]?.message).toContain("schema compilation failed");
+	});
+
 	test("caches compiled validators", () => {
 		const tool = makeTool("cached_tool", {
 			type: "object",


### PR DESCRIPTION
## Summary

Security audit and fixes for 6 vulnerabilities:

- **CRITICAL: Shell injection in `openBrowser()`** — Replaced `exec()` with `execFile()` in `src/client/browser.ts` so URLs are passed as array args, never interpreted by a shell. Added URL scheme validation to reject non-HTTP protocols. Previously, a malicious MCP server could craft a URL containing shell metacharacters that would be executed during OAuth redirects or elicitation.
- **HIGH: AJV silent validation bypass** — Fixed `src/validation/schema.ts` to return `valid: false` when schema compilation fails, instead of silently passing. A malicious server could previously craft schemas that trigger compilation errors to bypass all input validation.
- **MEDIUM: Incomplete header masking** — Expanded `src/client/debug-fetch.ts` sensitive header set from 3 to 9 (added `x-api-key`, `api-key`, `proxy-authorization`, `x-auth-token`, `x-token`, `token`). Reduced leaked prefix from 12 to 4 characters; fully masks values ≤ 6 chars.
- **MEDIUM: Plaintext auth.json permissions** — `src/config/loader.ts` now sets `0600` permissions on `auth.json` after write so OAuth tokens aren't readable by other users on shared systems.
- **MEDIUM: Unbounded recursive JSON parsing** — Added depth limit (max 10) to `parseNestedJson()` in `src/output/formatter.ts` to prevent stack overflow from deeply nested server responses.
- **LOW: CWD config trust boundary** — Added stderr warning in `src/config/loader.ts` when falling back to `servers.json` from the current directory.

## Test plan

- [x] All 353 existing tests pass
- [x] New test: AJV returns `valid: false` on broken schemas
- [x] New test: auth.json file permissions are 0600
- [x] Updated tests: header masking covers all 9 sensitive headers with new thresholds
- [x] `bun lint` and `bun format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)