### PR TITLE
Add Conductor workspace setup scripts

### DIFF
--- a/.conductor/archive.sh
+++ b/.conductor/archive.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+MAIN=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+MAIN_BRANCH=$(git -C "$MAIN" rev-parse --abbrev-ref HEAD)
+
+if [ "$MAIN_BRANCH" = "main" ]; then
+  echo "Main worktree is on main — pulling latest"
+  git -C "$MAIN" pull
+else
+  echo "Main worktree is on $MAIN_BRANCH — fetching"
+  git -C "$MAIN" fetch
+fi

--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+bun install

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+	"scripts": {
+		"setup": "bash .conductor/setup.sh",
+		"archive": "bash .conductor/archive.sh"
+	}
+}


### PR DESCRIPTION
## Summary

- Add `conductor.json` declaring `setup` and `archive` lifecycle scripts.
- `.conductor/setup.sh` runs `bun install` when a new Conductor workspace is created.
- `.conductor/archive.sh` refreshes the main worktree on archive (pulls when on `main`, fetches otherwise) so subsequent workspaces branch off current code.

Pattern ported from `~/workspace/botholomew`, simplified for mcpx (no local state directory, no env files, no DB).

## Test plan

- [x] `bash .conductor/setup.sh` exits 0 and populates `node_modules/`
- [x] `bash .conductor/archive.sh` exits 0 and reports main-worktree state
- [x] `bun lint` passes
- [x] `bun test` passes (353 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)