### PR TITLE
Support repeatable flags and -- passthrough for stdio args in `mcpx add`

### DIFF
--- a/.claude/skills/mcpx.md
+++ b/.claude/skills/mcpx.md
@@ -199,20 +199,20 @@ mcpx deauth <server>           # remove stored auth
 
 ## `add` options
 
-| Flag                       | Purpose                                |
-| -------------------------- | -------------------------------------- |
-| `--command <cmd>`          | Command to run (stdio server)          |
-| `--args <a1,a2,...>`       | Comma-separated arguments              |
-| `--env <KEY=VAL,...>`      | Comma-separated environment variables  |
-| `--cwd <dir>`              | Working directory for the command      |
-| `--url <url>`              | Server URL (HTTP server)               |
-| `--header <Key:Value>`     | HTTP header (repeatable)               |
-| `--transport <type>`       | Transport: `sse` or `streamable-http`  |
-| `--allowed-tools <t1,t2>`  | Comma-separated allowed tool patterns  |
-| `--disabled-tools <t1,t2>` | Comma-separated disabled tool patterns |
-| `-f, --force`              | Overwrite if server already exists     |
-| `--no-auth`                | Skip automatic OAuth after adding      |
-| `--no-index`               | Skip rebuilding the search index       |
+| Flag                     | Purpose                                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `--command <cmd>`        | Command to run (stdio server)                                                                               |
+| `--args <arg>`           | Argument for the command. Repeatable, or comma-separated. Tokens after `--` are also appended (stdio only). |
+| `--env <KEY=VAL>`        | Environment variable. Repeatable, or comma-separated.                                                       |
+| `--cwd <dir>`            | Working directory for the command                                                                           |
+| `--url <url>`            | Server URL (HTTP server)                                                                                    |
+| `--header <Key:Value>`   | HTTP header. Repeatable.                                                                                    |
+| `--transport <type>`     | Transport: `sse` or `streamable-http`                                                                       |
+| `--allowed-tools <pat>`  | Allowed tool pattern. Repeatable, or comma-separated.                                                       |
+| `--disabled-tools <pat>` | Disabled tool pattern. Repeatable, or comma-separated.                                                      |
+| `-f, --force`            | Overwrite if server already exists                                                                          |
+| `--no-auth`              | Skip automatic OAuth after adding                                                                           |
+| `--no-index`             | Skip rebuilding the search index                                                                            |
 
 ## `remove` options
 

--- a/.cursor/rules/mcpx.mdc
+++ b/.cursor/rules/mcpx.mdc
@@ -193,20 +193,20 @@ mcpx deauth <server>           # remove stored auth
 
 ## `add` options
 
-| Flag                       | Purpose                                |
-| -------------------------- | -------------------------------------- |
-| `--command <cmd>`          | Command to run (stdio server)          |
-| `--args <a1,a2,...>`       | Comma-separated arguments              |
-| `--env <KEY=VAL,...>`      | Comma-separated environment variables  |
-| `--cwd <dir>`              | Working directory for the command      |
-| `--url <url>`              | Server URL (HTTP server)               |
-| `--header <Key:Value>`     | HTTP header (repeatable)               |
-| `--transport <type>`       | Transport: `sse` or `streamable-http`  |
-| `--allowed-tools <t1,t2>`  | Comma-separated allowed tool patterns  |
-| `--disabled-tools <t1,t2>` | Comma-separated disabled tool patterns |
-| `-f, --force`              | Overwrite if server already exists     |
-| `--no-auth`                | Skip automatic OAuth after adding      |
-| `--no-index`               | Skip rebuilding the search index       |
+| Flag                     | Purpose                                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `--command <cmd>`        | Command to run (stdio server)                                                                               |
+| `--args <arg>`           | Argument for the command. Repeatable, or comma-separated. Tokens after `--` are also appended (stdio only). |
+| `--env <KEY=VAL>`        | Environment variable. Repeatable, or comma-separated.                                                       |
+| `--cwd <dir>`            | Working directory for the command                                                                           |
+| `--url <url>`            | Server URL (HTTP server)                                                                                    |
+| `--header <Key:Value>`   | HTTP header. Repeatable.                                                                                    |
+| `--transport <type>`     | Transport: `sse` or `streamable-http`                                                                       |
+| `--allowed-tools <pat>`  | Allowed tool pattern. Repeatable, or comma-separated.                                                       |
+| `--disabled-tools <pat>` | Disabled tool pattern. Repeatable, or comma-separated.                                                      |
+| `-f, --force`            | Overwrite if server already exists                                                                          |
+| `--no-auth`              | Skip automatic OAuth after adding                                                                           |
+| `--no-index`             | Skip rebuilding the search index                                                                            |
 
 ## `remove` options
 

--- a/README.md
+++ b/README.md
@@ -138,20 +138,24 @@ Server log messages (`notifications/message`) are displayed on stderr with level
 Add and remove servers from the CLI — no manual JSON editing required.
 
 ```bash
-# Add a stdio server
+# Add a stdio server (anything after `--` is passed to the command verbatim)
+mcpx add filesystem --command npx -- -y @modelcontextprotocol/server-filesystem /tmp
+
+# Equivalent forms: repeatable --args, or a single comma-separated --args
+mcpx add filesystem --command npx --args -y --args @modelcontextprotocol/server-filesystem --args /tmp
 mcpx add filesystem --command npx --args "-y,@modelcontextprotocol/server-filesystem,/tmp"
 
 # Add an HTTP server with headers
 mcpx add my-api --url https://api.example.com/mcp --header "Authorization:Bearer tok123"
 
-# Add with tool filtering
-mcpx add github --url https://mcp.github.com --allowed-tools "search_*,get_*"
+# Add with tool filtering (repeatable, or comma-separated)
+mcpx add github --url https://mcp.github.com --allowed-tools "search_*" --allowed-tools "get_*"
 
 # Add a legacy SSE server (explicit transport)
 mcpx add legacy-api --url https://api.example.com/sse --transport sse
 
-# Add with environment variables
-mcpx add my-server --command node --args "server.js" --env "API_KEY=sk-123,DEBUG=true"
+# Add with environment variables (repeatable, or comma-separated)
+mcpx add my-server --command node --args server.js --env API_KEY=sk-123 --env DEBUG=true
 
 # Overwrite an existing server
 mcpx add filesystem --command echo --force
@@ -168,20 +172,20 @@ mcpx remove my-api --dry-run
 
 **`add` options:**
 
-| Flag                       | Purpose                                |
-| -------------------------- | -------------------------------------- |
-| `--command <cmd>`          | Command to run (stdio server)          |
-| `--args <a1,a2,...>`       | Comma-separated arguments              |
-| `--env <KEY=VAL,...>`      | Comma-separated environment variables  |
-| `--cwd <dir>`              | Working directory for the command      |
-| `--url <url>`              | Server URL (HTTP server)               |
-| `--header <Key:Value>`     | HTTP header (repeatable)               |
-| `--transport <type>`       | Transport: `sse` or `streamable-http`  |
-| `--allowed-tools <t1,t2>`  | Comma-separated allowed tool patterns  |
-| `--disabled-tools <t1,t2>` | Comma-separated disabled tool patterns |
-| `-f, --force`              | Overwrite if server already exists     |
-| `--no-auth`                | Skip automatic OAuth after adding      |
-| `--no-index`               | Skip rebuilding the search index       |
+| Flag                       | Purpose                                                                |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `--command <cmd>`          | Command to run (stdio server)                                          |
+| `--args <arg>`             | Argument for the command. Repeatable, or comma-separated. Tokens after `--` are also appended (stdio only). |
+| `--env <KEY=VAL>`          | Environment variable. Repeatable, or comma-separated.                  |
+| `--cwd <dir>`              | Working directory for the command                                      |
+| `--url <url>`              | Server URL (HTTP server)                                               |
+| `--header <Key:Value>`     | HTTP header. Repeatable.                                               |
+| `--transport <type>`       | Transport: `sse` or `streamable-http`                                  |
+| `--allowed-tools <pat>`    | Allowed tool pattern. Repeatable, or comma-separated.                  |
+| `--disabled-tools <pat>`   | Disabled tool pattern. Repeatable, or comma-separated.                 |
+| `-f, --force`              | Overwrite if server already exists                                     |
+| `--no-auth`                | Skip automatic OAuth after adding                                      |
+| `--no-index`               | Skip rebuilding the search index                                       |
 
 **`remove` options:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.18.6",
+	"version": "0.18.7",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -6,33 +6,34 @@ import { runIndex } from "./index.ts";
 
 export function registerAddCommand(program: Command) {
 	program
-		.command("add <name>")
+		.command("add <name> [passthroughArgs...]")
 		.description("add an MCP server to your config")
 		.option("--command <cmd>", "command to run (stdio server)")
-		.option("--args <args>", "comma-separated arguments for the command")
-		.option("--env <vars>", "comma-separated KEY=VAL environment variables")
+		.option("--args <arg>", "argument for the command (repeatable, comma-separated, or pass after --)", collect, [])
+		.option("--env <KEY=VAL>", "environment variable (repeatable or comma-separated)", collect, [])
 		.option("--cwd <dir>", "working directory for the command")
 		.option("--url <url>", "server URL (HTTP server)")
 		.option("--header <h>", "header in Key:Value format (repeatable)", collect, [])
 		.option("--transport <type>", 'transport for HTTP servers: "sse" or "streamable-http"')
-		.option("--allowed-tools <tools>", "comma-separated list of allowed tools")
-		.option("--disabled-tools <tools>", "comma-separated list of disabled tools")
+		.option("--allowed-tools <pattern>", "allowed tool pattern (repeatable or comma-separated)", collect, [])
+		.option("--disabled-tools <pattern>", "disabled tool pattern (repeatable or comma-separated)", collect, [])
 		.option("-f, --force", "overwrite if server already exists")
 		.option("--no-auth", "skip automatic OAuth authentication after adding an HTTP server")
 		.option("--no-index", "skip rebuilding the search index after adding")
 		.action(
 			async (
 				name: string,
+				passthroughArgs: string[],
 				options: {
 					command?: string;
-					args?: string;
-					env?: string;
+					args: string[];
+					env: string[];
 					cwd?: string;
 					url?: string;
-					header?: string[];
+					header: string[];
 					transport?: string;
-					allowedTools?: string;
-					disabledTools?: string;
+					allowedTools: string[];
+					disabledTools: string[];
 					force?: boolean;
 					auth?: boolean;
 					index?: boolean;
@@ -49,6 +50,10 @@ export function registerAddCommand(program: Command) {
 					console.error("Cannot specify both --command and --url");
 					process.exit(1);
 				}
+				if (!hasCommand && passthroughArgs.length > 0) {
+					console.error("Positional arguments after -- only apply to stdio servers (--command)");
+					process.exit(1);
+				}
 
 				const configFlag = program.opts().config;
 				const { configDir, servers } = await loadRawServers(configFlag);
@@ -61,7 +66,7 @@ export function registerAddCommand(program: Command) {
 				let config: ServerConfig;
 
 				if (hasCommand) {
-					config = buildStdioConfig(options);
+					config = buildStdioConfig(options, passthroughArgs);
 				} else {
 					config = buildHttpConfig(options);
 				}
@@ -74,12 +79,13 @@ export function registerAddCommand(program: Command) {
 					(config as { transport: string }).transport = options.transport;
 				}
 
-				// Common options
-				if (options.allowedTools) {
-					config.allowedTools = options.allowedTools.split(",").map((t) => t.trim());
+				const allowedTools = splitCommaList(options.allowedTools);
+				if (allowedTools.length > 0) {
+					config.allowedTools = allowedTools;
 				}
-				if (options.disabledTools) {
-					config.disabledTools = options.disabledTools.split(",").map((t) => t.trim());
+				const disabledTools = splitCommaList(options.disabledTools);
+				if (disabledTools.length > 0) {
+					config.disabledTools = disabledTools;
 				}
 
 				// For HTTP servers, resolve the canonical resource URL before saving.
@@ -127,16 +133,26 @@ function collect(value: string, previous: string[]): string[] {
 	return previous.concat([value]);
 }
 
-function buildStdioConfig(options: { command?: string; args?: string; env?: string; cwd?: string }): ServerConfig {
+// Flatten a list of repeated CLI values, splitting each on commas and trimming.
+// Supports both `--flag a --flag b` and `--flag "a,b"` forms.
+function splitCommaList(values: string[]): string[] {
+	return values.flatMap((v) => v.split(",").map((s) => s.trim())).filter((s) => s.length > 0);
+}
+
+function buildStdioConfig(
+	options: { command?: string; args: string[]; env: string[]; cwd?: string },
+	passthroughArgs: string[],
+): ServerConfig {
 	const config: Record<string, unknown> = { command: options.command! };
 
-	if (options.args) {
-		config.args = options.args.split(",").map((a) => a.trim());
+	const args = [...splitCommaList(options.args), ...passthroughArgs];
+	if (args.length > 0) {
+		config.args = args;
 	}
 
-	if (options.env) {
+	if (options.env.length > 0) {
 		const env: Record<string, string> = {};
-		for (const pair of options.env.split(",")) {
+		for (const pair of splitCommaList(options.env)) {
 			const eqIdx = pair.indexOf("=");
 			if (eqIdx === -1) {
 				console.error(`Invalid env format "${pair}", expected KEY=VAL`);
@@ -154,10 +170,10 @@ function buildStdioConfig(options: { command?: string; args?: string; env?: stri
 	return config as unknown as ServerConfig;
 }
 
-function buildHttpConfig(options: { url?: string; header?: string[] }): ServerConfig {
+function buildHttpConfig(options: { url?: string; header: string[] }): ServerConfig {
 	const config: Record<string, unknown> = { url: options.url! };
 
-	if (options.header && options.header.length > 0) {
+	if (options.header.length > 0) {
 		const headers: Record<string, string> = {};
 		for (const h of options.header) {
 			const colonIdx = h.indexOf(":");

--- a/test/commands/add-remove.test.ts
+++ b/test/commands/add-remove.test.ts
@@ -119,6 +119,129 @@ describe("mcpx add", () => {
 		expect(servers.mcpServers.filtered.disabledTools).toEqual(["delete"]);
 	});
 
+	test("passes args after -- to the stdio command", async () => {
+		const { exitCode } = await run([
+			"-c",
+			tmpDir,
+			"add",
+			"playwright",
+			"--command",
+			"bunx",
+			"--no-index",
+			"--",
+			"@playwright/mcp@latest",
+			"--allowed-origins=*",
+		]);
+		expect(exitCode).toBe(0);
+
+		const servers = await Bun.file(join(tmpDir, "servers.json")).json();
+		expect(servers.mcpServers.playwright).toEqual({
+			command: "bunx",
+			args: ["@playwright/mcp@latest", "--allowed-origins=*"],
+		});
+	});
+
+	test("accepts repeatable --args", async () => {
+		const { exitCode } = await run([
+			"-c",
+			tmpDir,
+			"add",
+			"repeat",
+			"--command",
+			"echo",
+			"--args",
+			"hello",
+			"--args",
+			"world",
+			"--no-index",
+		]);
+		expect(exitCode).toBe(0);
+
+		const servers = await Bun.file(join(tmpDir, "servers.json")).json();
+		expect(servers.mcpServers.repeat.args).toEqual(["hello", "world"]);
+	});
+
+	test("merges --args flags with -- passthrough", async () => {
+		const { exitCode } = await run([
+			"-c",
+			tmpDir,
+			"add",
+			"mixed",
+			"--command",
+			"bunx",
+			"--args",
+			"@playwright/mcp@latest",
+			"--no-index",
+			"--",
+			"--allowed-origins=*",
+		]);
+		expect(exitCode).toBe(0);
+
+		const servers = await Bun.file(join(tmpDir, "servers.json")).json();
+		expect(servers.mcpServers.mixed.args).toEqual(["@playwright/mcp@latest", "--allowed-origins=*"]);
+	});
+
+	test("accepts repeatable --env", async () => {
+		const { exitCode } = await run([
+			"-c",
+			tmpDir,
+			"add",
+			"envs",
+			"--command",
+			"echo",
+			"--env",
+			"KEY=val",
+			"--env",
+			"FOO=bar",
+			"--no-index",
+		]);
+		expect(exitCode).toBe(0);
+
+		const servers = await Bun.file(join(tmpDir, "servers.json")).json();
+		expect(servers.mcpServers.envs.env).toEqual({ KEY: "val", FOO: "bar" });
+	});
+
+	test("accepts repeatable --allowed-tools and --disabled-tools", async () => {
+		const { exitCode } = await run([
+			"-c",
+			tmpDir,
+			"add",
+			"filtered2",
+			"--command",
+			"echo",
+			"--allowed-tools",
+			"read",
+			"--allowed-tools",
+			"write",
+			"--disabled-tools",
+			"delete",
+			"--disabled-tools",
+			"drop",
+			"--no-index",
+		]);
+		expect(exitCode).toBe(0);
+
+		const servers = await Bun.file(join(tmpDir, "servers.json")).json();
+		expect(servers.mcpServers.filtered2.allowedTools).toEqual(["read", "write"]);
+		expect(servers.mcpServers.filtered2.disabledTools).toEqual(["delete", "drop"]);
+	});
+
+	test("rejects -- passthrough on http servers", async () => {
+		const { exitCode, stderr } = await run([
+			"-c",
+			tmpDir,
+			"add",
+			"bad-http",
+			"--url",
+			"https://example.com",
+			"--no-index",
+			"--",
+			"oops",
+		]);
+		expect(exitCode).not.toBe(0);
+		expect(stderr).toContain("only apply to stdio");
+	});
+
 	test("errors if server already exists without --force", async () => {
 		await run(["-c", tmpDir, "add", "dupe", "--command", "echo", "--no-index"]);
 		const { exitCode, stderr } = await run(["-c", tmpDir, "add", "dupe", "--command", "cat", "--no-index"]);


### PR DESCRIPTION
## Summary

- `--args`, `--env`, `--allowed-tools`, and `--disabled-tools` are now repeatable in addition to the existing comma-separated form.
- Stdio servers also accept positional tokens after `--`, so the natural shell-style invocation works: `mcpx add playwright --command bunx -- @playwright/mcp@latest --allowed-origins=*`.
- Existing comma-separated form is preserved (back-compat); README, skill files, and Cursor rules updated; 7 new tests added (full suite 359/359 green).

## Test plan

- [x] `bun lint` — biome + tsc clean
- [x] `bun test` — 359 pass / 0 fail
- [x] Manual smoke: `--` passthrough, repeatable `--args`, repeatable `--env`, comma-separated form all produce the expected `servers.json`