### PR TITLE
Drop bun-darwin-x64 from release matrix (no upstream binding)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -92,8 +92,10 @@ jobs:
         include:
           - target: bun-darwin-arm64
             artifact: mcpx-darwin-arm64
-          - target: bun-darwin-x64
-            artifact: mcpx-darwin-x64
+          # Intel Mac (darwin/x64) is no longer supported: onnxruntime-node
+          # 1.24.3 (pulled in by @huggingface/transformers v4) dropped its
+          # darwin/x64 native binding. Drop the target rather than pin to an
+          # older, less-secure transformers release.
           - target: bun-linux-arm64
             artifact: mcpx-linux-arm64
           - target: bun-linux-x64

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.19.1",
+	"version": "0.19.2",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
## Why

The Auto Release workflow has been failing silently on every tag since the transformers v4 bump:

\`\`\`
error: Could not resolve: \"../bin/napi-v6/darwin/x64/onnxruntime_binding.node\"
\`\`\`

\`@huggingface/transformers@4.x\` depends on \`onnxruntime-node@1.24.3\`, which dropped its native binding for darwin/x64 (Intel Mac). The package's install metadata still lists \`darwin/x64\` as a target, but no binding ships in the npm tarball or the postinstall feed, so cross-target compilation can't link it.

| platform | onnxruntime-node 1.24.3 ships binding? |
|---|---|
| linux x64 / arm64 | ✓ |
| darwin arm64 | ✓ |
| **darwin x64** | **✗** |
| win32 x64 / arm64 | ✓ |

Apple stopped selling Intel Macs in 2023; pinning transformers back to v3 to recover the target isn't worth it.

## Changes

- Remove \`bun-darwin-x64\` from \`auto-release.yml\` matrix.
- Bump 0.19.1 → 0.19.2.

## Test plan

- [x] \`bun lint\` clean
- [ ] Auto Release workflow on the merge succeeds (it builds the matrix on tag push)