### PR TITLE
Bump version to 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.0",
+	"version": "0.22.0",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Version bump to 0.22.0 ahead of merging the auto-derive server name PR and the WASM embedder PR.

Splitting this out so the two feature PRs can be reviewed independently of the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)