### PR TITLE
Suppress stray log output during test runs

### DIFF
--- a/test/client/elicitation.test.ts
+++ b/test/client/elicitation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, type Mock, spyOn, test } from "bun:test";
 import type { ElicitRequest, ElicitRequestURLParams } from "@modelcontextprotocol/sdk/types.js";
 import { type ElicitationOptions, handleElicitation, handleUrlElicitation } from "../../src/client/elicitation.ts";
 
@@ -51,6 +51,16 @@ describe("handleElicitation", () => {
 });
 
 describe("handleUrlElicitation (direct, used for URL elicitation errors)", () => {
+	let stderrSpy: Mock<typeof process.stderr.write>;
+
+	beforeEach(() => {
+		stderrSpy = spyOn(process.stderr, "write").mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		stderrSpy.mockRestore();
+	});
+
 	test("noInteractive declines without prompting", async () => {
 		const params: ElicitRequestURLParams = {
 			mode: "url",

--- a/test/config/env.test.ts
+++ b/test/config/env.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { interpolateEnv, interpolateEnvString } from "../../src/config/env.ts";
 
 describe("interpolateEnvString", () => {
@@ -31,7 +31,13 @@ describe("interpolateEnvString", () => {
 
 	test("warns and returns empty on missing var in non-strict mode", () => {
 		process.env.MCP_STRICT_ENV = "false";
-		expect(interpolateEnvString("prefix-${DOES_NOT_EXIST}-suffix")).toBe("prefix--suffix");
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			expect(interpolateEnvString("prefix-${DOES_NOT_EXIST}-suffix")).toBe("prefix--suffix");
+			expect(warnSpy).toHaveBeenCalled();
+		} finally {
+			warnSpy.mockRestore();
+		}
 	});
 });
 

--- a/test/output/logger.test.ts
+++ b/test/output/logger.test.ts
@@ -15,6 +15,7 @@ describe("logger", () => {
 	afterEach(() => {
 		stderrSpy.mockRestore();
 		Object.defineProperty(process.stderr, "isTTY", { value: origIsTTY, writable: true });
+		logger.configure({});
 	});
 
 	test("info() writes dim text to stderr", () => {


### PR DESCRIPTION
## Summary

`bun test --dots` was leaking three independent log streams through the dot output. This PR keeps test runs clean without changing logger behavior in production:

- **JSON-mode notification leak** — `test/output/logger.test.ts` left the `logger` singleton in `{ json: true }` state, so later mock-server `notifications/message` calls in manager/trace tests printed `{"server":"mock",...}` lines. Reset the logger in `afterEach`.
- **Env warning leak** — the env-interpolation non-strict test in `test/config/env.test.ts` intentionally triggers `console.warn`. Spy on it (and assert the call) so the warning no longer prints.
- **URL elicitation leak** — the `noInteractive` URL path in `test/client/elicitation.test.ts` calls `logger.writeRaw`, which always writes regardless of TTY/JSON state. Spy on `process.stderr.write` around the affected describe block.

## Test plan
- [x] `bun test --dots` produces only dots and the summary
- [x] All 406 tests pass
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)