### PR TITLE
Upgrade embedding model to bge-small-en-v1.5; invalidate stale indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Contains every discovered tool with metadata for semantic search. Built and upda
 {
   "version": 1,
   "indexed_at": "2026-03-03T10:00:00Z",
-  "embedding_model": "Xenova/all-MiniLM-L6-v2",
+  "embedding_model": "Xenova/bge-small-en-v1.5",
   "tools": [
     {
       "server": "linear",
@@ -300,7 +300,7 @@ Each tool gets:
 - **keywords** — terms extracted by splitting the tool name on `_`, `-`, and camelCase boundaries
 - **embedding** — 384-dim vector for cosine similarity search
 
-Scenarios and keywords are extracted heuristically from tool names and descriptions. Embeddings are generated in-process using `Xenova/all-MiniLM-L6-v2` (~23MB ONNX model, downloaded on first run). No API keys needed.
+Scenarios and keywords are extracted heuristically from tool names and descriptions. Embeddings are generated in-process using `Xenova/bge-small-en-v1.5` (~33MB ONNX model, downloaded on first run). No API keys needed.
 
 ## Config Resolution Order
 
@@ -825,7 +825,7 @@ bun lint
 | MCP Client  | `@modelcontextprotocol/sdk`                           |
 | CLI Parsing | `commander`                                           |
 | Validation  | `ajv` (JSON Schema)                                   |
-| Embeddings  | `@huggingface/transformers` (Xenova/all-MiniLM-L6-v2) |
+| Embeddings  | `@huggingface/transformers` (Xenova/bge-small-en-v1.5) |
 
 ## Inspiration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.0",
+	"version": "0.21.1",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,10 +1,10 @@
 import type { Command } from "commander";
-import { DEFAULTS } from "../constants.ts";
+import { DEFAULTS, EMBEDDING_MODEL } from "../constants.ts";
 import { getContext } from "../context.ts";
 import { formatError, formatSearchResults } from "../output/formatter.ts";
 import { logger } from "../output/logger.ts";
 import { search } from "../search/index.ts";
-import { getStaleServers } from "../search/staleness.ts";
+import { getStaleServers, isEmbeddingModelStale } from "../search/staleness.ts";
 
 export function registerSearchCommand(program: Command) {
 	program
@@ -16,6 +16,13 @@ export function registerSearchCommand(program: Command) {
 		.action(async (terms: string[], options: { keyword?: boolean; query?: boolean; limit: string }) => {
 			const query = terms.join(" ");
 			const { config, formatOptions } = await getContext(program);
+
+			if (isEmbeddingModelStale(config.searchIndex)) {
+				logger.warn(
+					`Index was built with embedding model "${config.searchIndex.embedding_model}", but mcpx now uses "${EMBEDDING_MODEL.REPO}". Run: mcpx index`,
+				);
+				config.searchIndex.tools = [];
+			}
 
 			if (config.searchIndex.tools.length === 0) {
 				console.error(formatError("No search index found. Run: mcpx index", formatOptions));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,6 @@ export const DEFAULTS = {
 
 /** Hugging Face repo + revision used for the bundled embedding model. */
 export const EMBEDDING_MODEL = {
-	REPO: "Xenova/all-MiniLM-L6-v2",
+	REPO: "Xenova/bge-small-en-v1.5",
 	REVISION: "main",
 } as const;

--- a/src/search/staleness.ts
+++ b/src/search/staleness.ts
@@ -1,8 +1,14 @@
 import type { SearchIndex, ServersFile } from "../config/schemas.ts";
+import { EMBEDDING_MODEL } from "../constants.ts";
 
 /** Return server names that appear in the index but not in the current config */
 export function getStaleServers(index: SearchIndex, servers: ServersFile): string[] {
 	const configured = new Set(Object.keys(servers.mcpServers));
 	const indexed = new Set(index.tools.map((t) => t.server));
 	return [...indexed].filter((s) => !configured.has(s));
+}
+
+/** Return true if the index was built with a different embedding model than the one we'd use now. */
+export function isEmbeddingModelStale(index: SearchIndex): boolean {
+	return index.tools.length > 0 && index.embedding_model !== EMBEDDING_MODEL.REPO;
 }

--- a/test/search/staleness.test.ts
+++ b/test/search/staleness.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import type { SearchIndex, ServersFile } from "../../src/config/schemas.ts";
+import { EMBEDDING_MODEL } from "../../src/constants.ts";
+import { getStaleServers, isEmbeddingModelStale } from "../../src/search/staleness.ts";
+
+function makeIndex(overrides: Partial<SearchIndex> = {}): SearchIndex {
+	return {
+		version: 1,
+		indexed_at: "2026-05-03T00:00:00Z",
+		embedding_model: EMBEDDING_MODEL.REPO,
+		tools: [
+			{
+				server: "arcade",
+				tool: "Gmail_SendEmail",
+				description: "Send an email",
+				scenarios: [],
+				keywords: [],
+				embedding: [],
+			},
+		],
+		...overrides,
+	};
+}
+
+describe("getStaleServers", () => {
+	test("returns empty when every indexed server is configured", () => {
+		const index = makeIndex();
+		const servers: ServersFile = { mcpServers: { arcade: { url: "https://example.com" } } };
+		expect(getStaleServers(index, servers)).toEqual([]);
+	});
+
+	test("returns servers present in the index but missing from config", () => {
+		const index = makeIndex({
+			tools: [
+				{ server: "arcade", tool: "a", description: "", scenarios: [], keywords: [], embedding: [] },
+				{ server: "removed", tool: "b", description: "", scenarios: [], keywords: [], embedding: [] },
+			],
+		});
+		const servers: ServersFile = { mcpServers: { arcade: { url: "https://example.com" } } };
+		expect(getStaleServers(index, servers)).toEqual(["removed"]);
+	});
+});
+
+describe("isEmbeddingModelStale", () => {
+	test("returns false when the model matches the current constant", () => {
+		expect(isEmbeddingModelStale(makeIndex())).toBe(false);
+	});
+
+	test("returns true when the indexed model differs and tools are present", () => {
+		expect(isEmbeddingModelStale(makeIndex({ embedding_model: "Xenova/all-MiniLM-L6-v2" }))).toBe(true);
+	});
+
+	test("returns false when the index has no tools, even with a different model", () => {
+		expect(isEmbeddingModelStale(makeIndex({ embedding_model: "something-else", tools: [] }))).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- Swap `EMBEDDING_MODEL.REPO` from `Xenova/all-MiniLM-L6-v2` (MTEB ~56) to `Xenova/bge-small-en-v1.5` (MTEB ~62). Same 384-dim, ~10 MB larger ONNX, same `feature-extraction` + `device: "wasm"` + `dtype: "q8"` shape — `src/search/semantic.ts` reads the constant directly so no other code needed to change.
- Detect stale indexes on `mcpx search`: if `searchIndex.embedding_model` differs from the current `EMBEDDING_MODEL.REPO`, emit a yellow `logger.warn` with the old and new model names, empty out the tools array, and fall through the existing "No search index found. Run: mcpx index" path. Fail-closed (issue #79 option 1) — better than silently returning vectors-from-the-wrong-model.
- New helper `isEmbeddingModelStale` lives next to the existing `getStaleServers` in `src/search/staleness.ts`. Test file `test/search/staleness.test.ts` covers both helpers (the existing one was previously untested).
- README updated in three spots that named the old model (example `search.json`, embeddings paragraph, tech-stack table).
- Version bumped 0.21.0 → 0.21.1.

Brand-new/empty indexes (`tools.length === 0`) intentionally do **not** trigger the warning — only populated indexes built with a different model do.

Closes https://github.com/evantahler/mcpx/issues/79

## Test plan

- [x] \`bun lint\` clean
- [x] \`bun test test/search/staleness.test.ts\` — 5 pass
- [x] \`bun test\` — only pre-existing \`semantic.test.ts\` failures (unrelated WASM env in test runner; reproduce on clean tree)
- [ ] Manual: \`bun run dev -- index\`, confirm \`search.json\` records \`Xenova/bge-small-en-v1.5\`
- [ ] Manual: hand-edit \`search.json\` to old model name, run \`mcpx search "send an email"\`, confirm yellow warning + non-zero exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)