### PR TITLE
Apply transformers patch automatically when running bun test

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test/_preload.ts"]

--- a/test/_preload.ts
+++ b/test/_preload.ts
@@ -1,0 +1,21 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `src/search/semantic.ts` requests `device: "wasm"` from @huggingface/transformers,
+// which only works once the patch in `patches/` has been applied. The patch is
+// normally applied by `prebuild` and CI; apply it here so plain `bun test` works
+// out of the box. The script is idempotent (skips if its marker file exists).
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const marker = join(repoRoot, "node_modules/@huggingface/transformers/.mcpx-transformers-patch-applied");
+
+if (!existsSync(marker)) {
+	const result = spawnSync("bash", ["scripts/apply-transformers-patch.sh"], {
+		cwd: repoRoot,
+		stdio: "inherit",
+	});
+	if (result.status !== 0) {
+		throw new Error(`Failed to apply transformers patch (exit ${result.status})`);
+	}
+}


### PR DESCRIPTION
## Summary
- `src/search/semantic.ts` requests `device: \"wasm\"` from `@huggingface/transformers`, which only works after the patch in `patches/` is applied.
- Previously the patch was only applied by `prebuild` and CI, so a fresh `bun test` failed with `Unsupported device: \"wasm\"`.
- Adds a `bunfig.toml` test preload (`test/_preload.ts`) that invokes the existing idempotent `scripts/apply-transformers-patch.sh` if the marker file is missing.

## Test plan
- [x] Remove `node_modules/@huggingface/transformers`, reinstall, then `bun test` — preload patches and all 406 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)