### PR TITLE
Fix build-binaries: apply transformers patch before bun build

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
+      - run: bash scripts/apply-transformers-patch.sh
       - name: Build binary
         run: |
           bun build --compile --minify --sourcemap \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.1",
+	"version": "0.21.2",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
## Summary
- The `build-binaries` matrix job in `auto-release.yml` ran `bun build --compile` against an unpatched `@huggingface/transformers`, which still has a static `import 'onnxruntime-node'`. Every target failed with `Could not resolve onnxruntime_binding.node` (run [25303049308](https://github.com/evantahler/mcpx/actions/runs/25303049308)).
- Add `bash scripts/apply-transformers-patch.sh` between install and build, mirroring the `ci` job. Locally the same patch fires via the `prebuild` npm hook, but `bun build --compile` is the bundler CLI (not `bun run build`), so the hook does not fire in CI.
- Bump version to 0.21.2 so this also retriggers the release and produces the binaries that v0.21.1 missed.

## Test plan
- [ ] CI (`ci` job) passes on this PR.
- [ ] After merge, `auto-release` `build-binaries` matrix turns green for all 6 targets and uploads `mcpx-{darwin,linux,windows}-{x64,arm64}` to the v0.21.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)