### PR TITLE
Fix "Unsupported device: wasm" for npm-installed mcpx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.2",
+	"version": "0.21.3",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/search/semantic.ts
+++ b/src/search/semantic.ts
@@ -16,10 +16,14 @@ async function getEmbedder(): Promise<(text: string) => Promise<Float32Array>> {
 
 	const transformers = await import("@huggingface/transformers");
 
-	// transformers.js is patched (see patches/@huggingface%2Ftransformers@4.2.0.patch,
-	// applied by `bun run scripts/apply-transformers-patch.sh` during prebuild) to
-	// force the WASM backend instead of onnxruntime-node — the native bindings can't
-	// be bundled into the Bun --compile single binary.
+	// In the `bun --compile` binary and during local dev/CI, transformers is
+	// patched (patches/@huggingface%2Ftransformers@4.2.0.patch, applied by
+	// scripts/apply-transformers-patch.sh) so the only supported device is
+	// `wasm` via onnxruntime-web — native bindings can't be bundled into the
+	// single binary. For npm-installed mcpx the package is unpatched and `wasm`
+	// is rejected; we try `wasm` first and fall back to `cpu` (onnxruntime-node
+	// native bindings, which the user already has from npm) on the
+	// "Unsupported device" error.
 	const ortWasm = transformers.env.backends.onnx?.wasm;
 	if (ortWasm) {
 		ortWasm.numThreads = 1;
@@ -52,14 +56,23 @@ async function getEmbedder(): Promise<(text: string) => Promise<Float32Array>> {
 	transformers.env.cacheDir = userCacheDir;
 	transformers.env.localModelPath = join(userCacheDir, "models");
 
-	// WASM device defaults to q8 quantization, which gives near-identical
-	// embedding quality at ~25% the model size (≈22 MB vs ≈86 MB for fp32).
-	// Both CI and `bun run build` apply the transformers patch first, so
-	// wasm is the only supported device in this codepath.
-	const extractor = await transformers.pipeline("feature-extraction", EMBEDDING_MODEL.REPO, {
-		device: "wasm",
-		dtype: "q8",
-	});
+	// q8 quantization gives near-identical embedding quality at ~25% the model
+	// size (≈22 MB vs ≈86 MB for fp32). See onnx setup comment above for why
+	// we try `wasm` first and fall back to `cpu`.
+	let extractor: Awaited<ReturnType<typeof transformers.pipeline>>;
+	try {
+		extractor = await transformers.pipeline("feature-extraction", EMBEDDING_MODEL.REPO, {
+			device: "wasm",
+			dtype: "q8",
+		});
+	} catch (err) {
+		if (!String((err as Error)?.message ?? "").includes("Unsupported device")) throw err;
+		logger.debug("WASM backend unavailable; falling back to cpu (onnxruntime-node)");
+		extractor = await transformers.pipeline("feature-extraction", EMBEDDING_MODEL.REPO, {
+			device: "cpu",
+			dtype: "q8",
+		});
+	}
 
 	pipelineInstance = async (text: string): Promise<Float32Array> => {
 		const output = await extractor(text, { pooling: "mean", normalize: true });


### PR DESCRIPTION
## Summary
- Reported by user: `bun install -g @evantahler/mcpx@0.21.2` then `mcpx index` fails with `Error: Unsupported device: "wasm". Should be one of: coreml, webgpu, cpu.`
- Cause: the `wasm` device only exists in the *patched* `@huggingface/transformers` (the patch reroutes the node-env branch to `onnxruntime-web` and sets `supportedDevices = ['wasm']`). The patch lives in the build pipeline (`prebuild` + CI) and never reaches the npm-published tarball, so users get the unpatched transformers + native `onnxruntime-node` bindings, where `wasm` is rejected.
- Fix in `src/search/semantic.ts`: try `device: "wasm"` first; on `"Unsupported device"` errors, fall back to `device: "cpu"` (npm-installed mcpx already has working `onnxruntime-node` native bindings via the transitive dep). Patched binary path is unchanged — wasm just works.
- Bumps version to 0.21.3.

## Test plan
- [x] `bun lint` clean
- [x] `bun test` — 411 pass with patched transformers (wasm path)
- [ ] Post-release: `bun install -g @evantahler/mcpx@0.21.3` then `mcpx index` succeeds (cpu fallback path)
- [ ] Bundled binaries from auto-release still work (wasm path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)