### PR TITLE
Suppress tsc TS2307 on onnx-wasm-paths static imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.3",
+	"version": "0.21.4",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/search/onnx-wasm-paths.ts
+++ b/src/search/onnx-wasm-paths.ts
@@ -10,9 +10,20 @@
 // that environment node_modules exists and onnxruntime-web is reachable
 // through normal module resolution.
 
+// The relative `../../node_modules/...` paths only resolve from the local repo
+// layout (and inside `bun build --compile`). When this file is shipped via npm,
+// deps are hoisted, so consumer `tsc` runs hit TS2307. The `ts-ignore` directive
+// below silences that for consumers; we avoid the stricter `expect-error` form
+// because in the local repo the path resolves fine and there would be no error
+// to expect. At runtime the dynamic import in semantic.ts is wrapped in
+// try/catch and falls back to transformers.js's default WASM loader (issue #85).
+// biome-ignore lint/suspicious/noTsIgnore: must stay as ts-ignore per comment above
+// @ts-ignore - dynamic-only import
 import wasmMjsPath from "../../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.mjs" with {
 	type: "file",
 };
+// biome-ignore lint/suspicious/noTsIgnore: must stay as ts-ignore per comment above
+// @ts-ignore - dynamic-only import
 import wasmBinPath from "../../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.wasm" with {
 	type: "file",
 };


### PR DESCRIPTION
## Summary

- Adds `// @ts-ignore` to the two `with { type: "file" }` imports in `src/search/onnx-wasm-paths.ts` so downstream consumers running `tsc --noEmit` no longer hit `TS2307` on the relative `../../node_modules/onnxruntime-web/dist/...` paths.
- Pairs each `@ts-ignore` with a `// biome-ignore lint/suspicious/noTsIgnore: ...` comment so biome doesn't auto-rewrite to `@ts-expect-error` (which would itself error locally, where the path resolves fine).
- Bumps `package.json` to `0.21.4`.

The runtime behavior is unchanged: the file is loaded only via a `try { await import("./onnx-wasm-paths.ts") } catch {}` in `semantic.ts`, and consumer environments fall through to transformers.js's default WASM loader.

Closes https://github.com/evantahler/mcpx/issues/85

## Test plan

- [x] `bun lint` (biome + tsc) clean locally.
- [x] `bun test` — 411/411 pass.
- [x] Reproduced consumer scenario via `bun pm pack` + `bun add ./tarball.tgz` in a fresh project. Without the fix, `bunx tsc --noEmit` emits the exact `TS2307` errors from the issue; with the fix applied, those errors are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)