### PR TITLE
Normalize array+sibling-enum schemas before validation (closes #87)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.4",
+	"version": "0.21.5",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -26,7 +26,7 @@ function validateWithSchema(
 
 	if (!validate) {
 		try {
-			validate = ajv.compile(schema);
+			validate = ajv.compile(normalizeSchema(schema));
 			validatorCache.set(cacheKey, validate);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : "unknown error";
@@ -58,6 +58,64 @@ export function validateElicitationResponse(
 	input: Record<string, unknown>,
 ): ValidationResult {
 	return validateWithSchema(`__elicitation__${JSON.stringify(schema)}`, schema, input);
+}
+
+type JsonPrimitive = string | number | boolean | null;
+
+function isPrimitive(v: unknown): v is JsonPrimitive {
+	return v === null || ["string", "number", "boolean"].includes(typeof v);
+}
+
+function primitiveJsonType(v: JsonPrimitive): "string" | "number" | "boolean" | "null" {
+	if (v === null) return "null";
+	if (typeof v === "boolean") return "boolean";
+	if (typeof v === "number") return "number";
+	return "string";
+}
+
+/**
+ * Normalize a JSON Schema before handing it to Ajv. Rewrites the malformed
+ * shape `{ type: "array", enum: [<primitives>], items: { type: <matching> } }`
+ * — published by some real MCP servers — into `{ type: "array", items: { ..., enum: [...] } }`.
+ * Without this fix Ajv compares the whole array value against the primitive enum
+ * and rejects every input. Returns a deep clone; the input schema is untouched.
+ */
+function normalizeSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	return walk(schema) as Record<string, unknown>;
+}
+
+function walk(node: unknown): unknown {
+	if (Array.isArray(node)) {
+		return node.map(walk);
+	}
+	if (!node || typeof node !== "object") {
+		return node;
+	}
+
+	const out: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+		out[key] = walk(value);
+	}
+
+	if (out.type === "array" && Array.isArray(out.enum) && out.enum.every(isPrimitive)) {
+		const items = out.items;
+		const enumValues = out.enum as JsonPrimitive[];
+		if (items && typeof items === "object" && !Array.isArray(items)) {
+			const itemsObj = items as Record<string, unknown>;
+			const enumType = primitiveJsonType(enumValues[0]!);
+			const allSameType = enumValues.every((v) => primitiveJsonType(v) === enumType);
+			const itemsTypeMatches =
+				itemsObj.type === undefined ||
+				itemsObj.type === enumType ||
+				(Array.isArray(itemsObj.type) && itemsObj.type.includes(enumType));
+			if (allSameType && itemsTypeMatches && itemsObj.enum === undefined) {
+				out.items = { ...itemsObj, enum: enumValues };
+				delete out.enum;
+			}
+		}
+	}
+
+	return out;
 }
 
 function formatAjvError(err: ErrorObject): ValidationError {

--- a/test/validation/schema.test.ts
+++ b/test/validation/schema.test.ts
@@ -116,6 +116,95 @@ describe("validateToolInput", () => {
 		expect(result.errors[0]?.message).toContain("schema compilation failed");
 	});
 
+	describe("array-with-sibling-enum normalization (issue #87)", () => {
+		const orderByEnum = ["createdTime", "createdTime desc", "viewedByMeTime", "viewedByMeTime desc"];
+
+		test("accepts array values that match a sibling primitive enum", () => {
+			const tool = makeTool("sibling_enum_pass", {
+				type: "object",
+				properties: {
+					order_by: {
+						type: "array",
+						items: { type: "string" },
+						enum: orderByEnum,
+					},
+				},
+			});
+			const result = validateToolInput("s1", tool, { order_by: ["viewedByMeTime desc"] });
+			expect(result.valid).toBe(true);
+		});
+
+		test("rejects entries that aren't in the (rewritten) item enum", () => {
+			const tool = makeTool("sibling_enum_fail", {
+				type: "object",
+				properties: {
+					order_by: {
+						type: "array",
+						items: { type: "string" },
+						enum: orderByEnum,
+					},
+				},
+			});
+			const result = validateToolInput("s2", tool, { order_by: ["nope"] });
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]?.path).toBe("order_by.0");
+			expect(result.errors[0]?.message).toContain("one of");
+		});
+
+		test("does not regress correctly-shaped items.enum schemas", () => {
+			const tool = makeTool("nested_enum_ok", {
+				type: "object",
+				properties: {
+					order_by: {
+						type: "array",
+						items: { type: "string", enum: orderByEnum },
+					},
+				},
+			});
+			const pass = validateToolInput("s3", tool, { order_by: ["createdTime"] });
+			expect(pass.valid).toBe(true);
+			const fail = validateToolInput("s3", tool, { order_by: ["nope"] });
+			expect(fail.valid).toBe(false);
+		});
+
+		test("leaves schema untouched when items.enum already exists", () => {
+			const tool = makeTool("both_enums", {
+				type: "object",
+				properties: {
+					order_by: {
+						type: "array",
+						items: { type: "string", enum: ["onlyA"] },
+						enum: ["onlyB"],
+					},
+				},
+			});
+			// If we had rewritten the parent enum into items.enum we would have silently
+			// overwritten the legitimate `["onlyA"]` constraint, and `["onlyB"]` would now pass.
+			// Confirm we did not: items.enum still rejects "onlyB".
+			const result = validateToolInput("s4", tool, { order_by: ["onlyB"] });
+			expect(result.valid).toBe(false);
+			expect(result.errors.some((e) => e.path === "order_by.0")).toBe(true);
+		});
+
+		test("leaves schema untouched when sibling enum contains non-primitives", () => {
+			const tool = makeTool("non_primitive_enum", {
+				type: "object",
+				properties: {
+					tuples: {
+						type: "array",
+						items: { type: "object" },
+						enum: [{ a: 1 }, { b: 2 }],
+					},
+				},
+			});
+			// The original (malformed) Ajv behavior is preserved here: array value
+			// is checked against the enum of objects and fails. We just verify we
+			// didn't accidentally rewrite it.
+			const result = validateToolInput("s5", tool, { tuples: [{ a: 1 }] });
+			expect(result.valid).toBe(false);
+		});
+	});
+
 	test("caches compiled validators", () => {
 		const tool = makeTool("cached_tool", {
 			type: "object",


### PR DESCRIPTION
## Summary

Some MCP servers (notably Arcade's `google-slack-tools`) publish input schemas where `enum` is a sibling of `type: array` instead of nested under `items`. Ajv compares the whole array value against the primitive enum and rejects every input — making tools like `GoogleDocs_SearchDocuments`, `GoogleDocs_SearchAndRetrieveDocuments`, and `GoogleDrive_SearchFiles` unreachable from `mcpx exec`.

## Changes

- `src/validation/schema.ts`: pre-walk schemas before Ajv compilation and move primitive `enum` down into `items.enum` when the shape is unambiguous (`type: array` + sibling primitive enum + matching/unset `items.type`, no existing `items.enum`). Operates on a deep clone so the upstream schema is untouched.
- `test/validation/schema.test.ts`: 5 new cases covering pass/fail of the rewritten schema, no regression for already-correct `items.enum`, and untouched behavior when both enums coexist or when the enum holds non-primitives.
- `package.json`: 0.21.4 → 0.21.5.

## Test plan

- [x] `bun lint` clean
- [x] `bun test` — 416/416 pass
- [ ] End-to-end: `mcpx exec google-slack-tools GoogleDocs_SearchDocuments '{"limit": 5, "order_by": ["viewedByMeTime desc"]}'` reaches the server instead of failing validation

Closes https://github.com/evantahler/mcpx/issues/87