### PR TITLE
Kill stdio MCP children on signal exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.5",
+	"version": "0.21.6",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,10 @@ import { registerSkillCommand } from "./commands/skill.ts";
 import { registerTaskCommand } from "./commands/task.ts";
 import { registerUpgradeCommand } from "./commands/upgrade.ts";
 import { logger } from "./output/logger.ts";
+import { ExitError, installSignalHandlers } from "./shutdown.ts";
 import { maybeCheckForUpdate } from "./update/background.ts";
+
+installSignalHandlers();
 
 program
 	.name("mcpx")
@@ -92,7 +95,15 @@ if (firstCommand && !knownCommands.has(firstCommand)) {
 // Fire-and-forget background update check
 const updateNotice = maybeCheckForUpdate();
 
-program.parse();
+try {
+	await program.parseAsync();
+} catch (err) {
+	if (err instanceof ExitError) {
+		process.exit(err.code);
+	}
+	logger.error(String(err));
+	process.exit(1);
+}
 
 // Print update notice after command output completes
 process.on("beforeExit", async () => {

--- a/src/client/manager.ts
+++ b/src/client/manager.ts
@@ -20,6 +20,7 @@ import pkg from "../../package.json";
 import type { AuthFile, Prompt, Resource, ServerConfig, ServersFile, Tool } from "../config/schemas.ts";
 import { isHttpServer, isStdioServer } from "../config/schemas.ts";
 import { logger } from "../output/logger.ts";
+import { register, unregister } from "../shutdown.ts";
 import { handleElicitation } from "./elicitation.ts";
 import { createHttpTransport } from "./http.ts";
 import { McpOAuthProvider } from "./oauth.ts";
@@ -97,6 +98,7 @@ export class ServerManager {
 		this.logLevel = opts.logLevel ?? "warning";
 		this.json = opts.json ?? false;
 		this.noInteractive = opts.noInteractive ?? false;
+		register(this);
 	}
 
 	/** Get or create a connected client for a server */
@@ -492,16 +494,19 @@ export class ServerManager {
 
 	/** Disconnect all clients */
 	async close(): Promise<void> {
-		const closePromises = [...this.clients.entries()].map(async ([name, client]) => {
+		unregister(this);
+		// Close every transport — covers in-flight connects whose client hasn't been promoted
+		// into `this.clients` yet (otherwise stdio children would be orphaned on shutdown).
+		const closePromises = [...this.transports.values()].map(async (transport) => {
 			try {
-				await client.close();
+				await transport.close?.();
 			} catch {
 				// Ignore close errors
 			}
-			this.clients.delete(name);
-			this.transports.delete(name);
 		});
 		await Promise.allSettled(closePromises);
+		this.clients.clear();
+		this.transports.clear();
 		this.connecting.clear();
 	}
 }

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -13,6 +13,7 @@ import {
 	formatValidationErrors,
 } from "../output/formatter.ts";
 import { logger } from "../output/logger.ts";
+import { ExitError } from "../shutdown.ts";
 import { validateToolInput } from "../validation/schema.ts";
 
 type ResolvedArgs =
@@ -268,10 +269,10 @@ export function registerExecCommand(program: Command) {
 						for (const elicitation of err.elicitations) {
 							await handleUrlElicitation(elicitation, elicitOptions);
 						}
-						process.exit(1);
+						throw new ExitError(1);
 					}
 					console.error(formatError(String(err), formatOptions));
-					process.exit(1);
+					throw new ExitError(1);
 				} finally {
 					await manager.close();
 				}

--- a/src/commands/with-command.ts
+++ b/src/commands/with-command.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { type AppContext, getContext } from "../context.ts";
 import { formatError } from "../output/formatter.ts";
 import { logger, type Spinner } from "../output/logger.ts";
+import { ExitError } from "../shutdown.ts";
 
 export interface CommandContext extends AppContext {
 	spinner: Spinner;
@@ -47,9 +48,10 @@ export function withCommand<TArgs extends unknown[]>(
 		try {
 			await handler({ ...appCtx, spinner }, ...args);
 		} catch (err) {
+			if (err instanceof ExitError) throw err;
 			spinner.error(options.errorLabel ?? "Failed");
 			console.error(formatError(String(err), formatOptions));
-			process.exit(1);
+			throw new ExitError(1);
 		} finally {
 			await manager.close();
 		}

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -1,0 +1,65 @@
+import { logger } from "./output/logger.ts";
+
+export interface Closeable {
+	close(): Promise<void>;
+}
+
+export class ExitError extends Error {
+	constructor(
+		public readonly code: number,
+		message?: string,
+	) {
+		super(message);
+		this.name = "ExitError";
+	}
+}
+
+const registry = new Set<Closeable>();
+let shuttingDown = false;
+
+export function register(c: Closeable): void {
+	registry.add(c);
+}
+
+export function unregister(c: Closeable): void {
+	registry.delete(c);
+}
+
+const HARD_TIMEOUT_MS = 8000;
+
+async function runShutdown(exitCode: number): Promise<never> {
+	if (shuttingDown) {
+		process.exit(exitCode);
+	}
+	shuttingDown = true;
+
+	const closeAll = Promise.allSettled([...registry].map((c) => c.close()));
+	await Promise.race([closeAll, new Promise<void>((resolve) => setTimeout(resolve, HARD_TIMEOUT_MS).unref())]);
+	process.exit(exitCode);
+}
+
+let installed = false;
+
+export function installSignalHandlers(): void {
+	if (installed) return;
+	installed = true;
+
+	process.on("SIGINT", () => {
+		void runShutdown(130);
+	});
+	process.on("SIGTERM", () => {
+		void runShutdown(143);
+	});
+	process.on("SIGHUP", () => {
+		void runShutdown(129);
+	});
+	process.on("uncaughtException", (err) => {
+		logger.error(`uncaught exception: ${err?.stack ?? String(err)}`);
+		void runShutdown(1);
+	});
+	process.on("unhandledRejection", (reason) => {
+		const detail = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+		logger.error(`unhandled rejection: ${detail}`);
+		void runShutdown(1);
+	});
+}

--- a/test/integration/stdio-shutdown.test.ts
+++ b/test/integration/stdio-shutdown.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+
+const CLI = join(import.meta.dir, "../../src/cli.ts");
+const CWD = join(import.meta.dir, "../..");
+const TMP_CONFIG = join(import.meta.dir, "../fixtures/_tmp_shutdown_config");
+
+function pidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function findStdioGrandchildPid(parentPid: number, timeoutMs = 5000): Promise<number | undefined> {
+	// `bun run src/cli.ts` may either run in-process or spawn a child bun. Walk one
+	// level down if the direct child is itself bun.
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const direct = await $`pgrep -P ${parentPid}`.nothrow().quiet();
+		if (direct.exitCode === 0) {
+			const pids = direct.stdout
+				.toString()
+				.trim()
+				.split("\n")
+				.map((s) => parseInt(s, 10))
+				.filter((n) => Number.isFinite(n));
+			for (const pid of pids) {
+				const cmd = (await $`ps -o command= -p ${pid}`.nothrow().quiet()).stdout.toString().trim();
+				if (cmd.startsWith("sleep")) return pid;
+				// Recurse one level — bun may have forked
+				const grand = await $`pgrep -P ${pid}`.nothrow().quiet();
+				if (grand.exitCode === 0) {
+					const gpids = grand.stdout
+						.toString()
+						.trim()
+						.split("\n")
+						.map((s) => parseInt(s, 10))
+						.filter((n) => Number.isFinite(n));
+					for (const gpid of gpids) {
+						const gcmd = (await $`ps -o command= -p ${gpid}`.nothrow().quiet()).stdout.toString().trim();
+						if (gcmd.startsWith("sleep")) return gpid;
+					}
+				}
+			}
+		}
+		await Bun.sleep(50);
+	}
+	return undefined;
+}
+
+async function waitForExit(pid: number, timeoutMs = 5000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!pidAlive(pid)) return true;
+		await Bun.sleep(50);
+	}
+	return false;
+}
+
+/**
+ * Reproduces and guards against the regression where stdio MCP child
+ * processes are orphaned when mcpx receives SIGINT / SIGTERM / SIGHUP.
+ *
+ * We use `sleep` as the stdio "server" — it ignores MCP protocol entirely,
+ * so mcpx's connect() hangs (its 30-min internal timeout). While mcpx hangs,
+ * the spawned `sleep` child is alive. We then signal mcpx and verify the
+ * child has died within a few seconds (the SDK's StdioClientTransport.close
+ * does stdin-EOF → SIGTERM → SIGKILL on a 4s ladder, so we wait 6s).
+ */
+describe("stdio child shutdown on signal", () => {
+	beforeAll(async () => {
+		await mkdir(TMP_CONFIG, { recursive: true });
+		await writeFile(
+			join(TMP_CONFIG, "servers.json"),
+			JSON.stringify({
+				mcpServers: {
+					hang: { command: "sleep", args: ["600"] },
+				},
+			}),
+		);
+	});
+
+	afterAll(async () => {
+		await rm(TMP_CONFIG, { recursive: true, force: true });
+	});
+
+	for (const signal of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+		test(`kills stdio child when mcpx receives ${signal}`, async () => {
+			const proc = Bun.spawn(["bun", "run", CLI, "-c", TMP_CONFIG, "ping", "hang"], {
+				stdout: "pipe",
+				stderr: "pipe",
+				cwd: CWD,
+			});
+
+			try {
+				const childPid = await findStdioGrandchildPid(proc.pid);
+				expect(childPid, "mcpx should have spawned a stdio child").toBeDefined();
+				expect(pidAlive(childPid!)).toBe(true);
+
+				proc.kill(signal);
+
+				const died = await waitForExit(childPid!, 6000);
+				expect(died, `stdio child (pid ${childPid}) should die after mcpx got ${signal}`).toBe(true);
+			} finally {
+				try {
+					proc.kill("SIGKILL");
+				} catch {
+					// ignore
+				}
+				await proc.exited;
+			}
+		}, 20000);
+	}
+});


### PR DESCRIPTION
Stdio MCP server children (e.g. `macos-ts`) were being orphaned when mcpx exited via SIGINT/SIGTERM/SIGHUP/uncaught error — `cli.ts` had no top-level signal handlers, a few `process.exit(1)` calls bypassed their own `finally { manager.close() }`, and `manager.close()` iterated `this.clients` (empty during in-flight connects) instead of `this.transports`.

Fix: new `src/shutdown.ts` with a close-registry + `ExitError` + signal handlers; `ServerManager` self-registers and `close()` now tears down transports; offending `process.exit(1)` calls in `exec.ts` and `with-command.ts` became `throw new ExitError(1)`; `cli.ts` switched to `parseAsync` with a top-level catch.

New integration test (`test/integration/stdio-shutdown.test.ts`) spawns mcpx with a `sleep 600` fake stdio server, sends each of SIGTERM/SIGINT/SIGHUP, and asserts the grandchild dies within 6s — fails on `main`, passes on this branch. Full suite: 419/419 passing.