### PR TITLE
Drop typescript peer dep to silence install-time warning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,9 +20,6 @@
         "@types/bun": "latest",
         "typescript": "^6",
       },
-      "peerDependencies": {
-        "typescript": "^6",
-      },
     },
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.7",
+	"version": "0.21.8",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {
@@ -59,9 +59,6 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.14",
 		"@types/bun": "latest",
-		"typescript": "^6"
-	},
-	"peerDependencies": {
 		"typescript": "^6"
 	}
 }


### PR DESCRIPTION
Installing downstream packages globally (e.g. `bun install -g botholomew`, which depends on `@evantahler/mcpx`) currently surfaces:

```
warn: incorrect peer dependency "typescript@5.9.3"
```

The `typescript` peer dep isn't load-bearing — this package ships raw `.ts` from `src/` and Bun runs `.ts` natively, so consumers don't need any specific `typescript` version installed. Dropping the peer entry removes the noise. `devDependencies.typescript` stays for local dev / `tsc --noEmit`.

Parallel PRs are going up in `macos-ts` and `membot` for the same fix.