### PR TITLE
Dedupe and clarify per-server connection errors in list command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.8",
+	"version": "0.21.9",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import type { UnifiedItem } from "../output/formatter.ts";
-import { formatUnifiedList } from "../output/formatter.ts";
+import { formatError, formatUnifiedList } from "../output/formatter.ts";
 import { withCommand } from "./with-command.ts";
 
 export function registerListCommand(program: Command) {
@@ -46,8 +46,17 @@ export function registerListCommand(program: Command) {
 
 				const errors = [...toolsResult.errors, ...resourcesResult.errors, ...promptsResult.errors];
 				if (errors.length > 0) {
+					const messagesByServer = new Map<string, Set<string>>();
 					for (const err of errors) {
-						console.error(`"${err.server}": ${err.message}`);
+						let set = messagesByServer.get(err.server);
+						if (!set) {
+							set = new Set();
+							messagesByServer.set(err.server, set);
+						}
+						set.add(err.message);
+					}
+					for (const [server, messages] of messagesByServer) {
+						console.error(formatError(`Server "${server}": ${[...messages].join("; ")}`, formatOptions));
 					}
 					if (items.length > 0) console.log("");
 				}


### PR DESCRIPTION
## Summary

The default list command fans out `getAllTools` / `getAllResources` / `getAllPrompts` in parallel, so a single broken stdio server (e.g. `command: \"echo\"`) produced three identical `\"echo\": MCP error -32000: Connection closed` lines. Now the errors are deduped per server and routed through `formatError`, so the output matches the `prompt` / `resource` commands and clearly identifies which server failed (`✗ error: Server \"echo\": MCP error -32000: Connection closed`).

## Test plan

- [x] Reproduced the bug locally with an `echo` stdio entry in `~/.mcpx/servers.json` — three identical lines before, one after.
- [x] `bun lint` and `bun run format` clean.
- [x] `bun test` — 443 pass.