### PR TITLE
Auto-reindex servers when their tools change

### DIFF
--- a/.claude/skills/mcpx.md
+++ b/.claude/skills/mcpx.md
@@ -99,7 +99,7 @@ mcpx exec filesystem read_file -f params.json
 - **"Not authenticated" / 401 error** → Run `mcpx auth <server>` to start the OAuth flow
 - **Exec timeout** → Use `-v` to see where it stalls; set `MCP_TIMEOUT=<seconds>` to increase the timeout (default: 1800)
 - **Search returns no results** → Try `mcpx search -k "*keyword*"` for glob matching, or `mcpx index` to rebuild the search index
-- **Missing or stale tools** → Run `mcpx index` to rebuild; any command that connects to a server also auto-updates the index
+- **Missing or stale tools** → Run `mcpx index` to rebuild; `mcpx` (the default list) and `mcpx index -i` also auto-refresh the index for any server whose tools have changed
 - **Server won't connect** → Run `mcpx ping <server>` to check connectivity; use `-v` for protocol-level details
 - **Auth token expired** → Run `mcpx auth <server> -r` to force a token refresh
 

--- a/.cursor/rules/mcpx.mdc
+++ b/.cursor/rules/mcpx.mdc
@@ -79,7 +79,7 @@ mcpx exec filesystem read_file -f params.json
 - **"Not authenticated" / 401 error** → Run `mcpx auth <server>` to start the OAuth flow
 - **Exec timeout** → Use `-v` to see where it stalls; set `MCP_TIMEOUT=<seconds>` to increase the timeout (default: 1800)
 - **Search returns no results** → Try `mcpx search -k "*keyword*"` for glob matching, or `mcpx index` to rebuild the search index
-- **Missing or stale tools** → Run `mcpx index` to rebuild; any command that connects to a server also auto-updates the index
+- **Missing or stale tools** → Run `mcpx index` to rebuild; `mcpx` (the default list) and `mcpx index -i` also auto-refresh the index for any server whose tools have changed
 - **Server won't connect** → Run `mcpx ping <server>` to check connectivity; use `-v` for protocol-level details
 - **Auth token expired** → Run `mcpx auth <server> -r` to force a token refresh
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Tokens are automatically refreshed when expired (if a refresh token is available
 
 ### `search.json` — Semantic Search Index (managed automatically)
 
-Contains every discovered tool with metadata for semantic search. Built and updated automatically — any command that connects to a server will detect new/changed tools and re-index them in the background.
+Contains every discovered tool with metadata for semantic search. Built by `mcpx index` and kept fresh automatically — `mcpx` (the default list) and `mcpx index --status` already fetch every server's live tools, so they detect new/changed/removed tools and re-index the affected servers in the background.
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.9",
+	"version": "0.21.10",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,7 @@ import type { Command } from "commander";
 import { saveSearchIndex } from "../config/loader.ts";
 import { getContext } from "../context.ts";
 import { logger } from "../output/logger.ts";
+import { maybeReindexDrift } from "../search/auto-reindex.ts";
 import { buildSearchIndex } from "../search/indexer.ts";
 import { getStaleServers } from "../search/staleness.ts";
 import { withCommand } from "./with-command.ts";
@@ -34,21 +35,37 @@ export function registerIndexCommand(program: Command) {
 		.option("-i, --status", "show index status")
 		.action(async (options: { status?: boolean }) => {
 			if (options.status) {
-				const { config, manager } = await getContext(program);
-				const idx = config.searchIndex;
-				if (idx.tools.length === 0) {
-					console.log("No search index. Run: mcpx index");
-				} else {
+				const { config, manager, formatOptions } = await getContext(program);
+				try {
+					if (config.searchIndex.tools.length === 0) {
+						console.log("No search index. Run: mcpx index");
+						return;
+					}
+
+					// Connect to servers and refresh the index for any whose tools have drifted.
+					const spinner = logger.startSpinner("Checking servers for tool changes...", formatOptions);
+					const { tools, errors } = await manager.getAllTools();
+					const { servers: reindexed } = await maybeReindexDrift(config, tools, errors, (p) => {
+						spinner.update(`Re-indexing ${p.current}/${p.total}: ${p.tool}`);
+					});
+					spinner.stop();
+
+					const idx = config.searchIndex;
 					console.log(`Tools:   ${idx.tools.length}`);
 					console.log(`Model:   ${idx.embedding_model}`);
 					console.log(`Indexed: ${idx.indexed_at}`);
+
+					if (reindexed.length > 0) {
+						console.log(`Refreshed: ${reindexed.join(", ")} (tools changed since last index)`);
+					}
 
 					const stale = getStaleServers(idx, config.servers);
 					if (stale.length > 0) {
 						console.log(yellow(`Stale:   ${stale.join(", ")} (run mcpx index to refresh)`));
 					}
+				} finally {
+					await manager.close();
 				}
-				await manager.close();
 				return;
 			}
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,10 @@
 import type { Command } from "commander";
-import type { UnifiedItem } from "../output/formatter.ts";
+import type { ServerError, ToolWithServer } from "../client/manager.ts";
+import type { Config } from "../config/schemas.ts";
+import type { FormatOptions, UnifiedItem } from "../output/formatter.ts";
 import { formatError, formatUnifiedList } from "../output/formatter.ts";
+import { logger } from "../output/logger.ts";
+import { maybeReindexDrift } from "../search/auto-reindex.ts";
 import { withCommand } from "./with-command.ts";
 
 export function registerListCommand(program: Command) {
@@ -8,13 +12,17 @@ export function registerListCommand(program: Command) {
 		withCommand(
 			program,
 			{ spinnerText: "Connecting to servers...", errorLabel: "Failed to list servers" },
-			async ({ manager, formatOptions, spinner }) => {
+			async ({ config, manager, formatOptions, spinner }) => {
 				const [toolsResult, resourcesResult, promptsResult] = await Promise.all([
 					manager.getAllTools(),
 					manager.getAllResources(),
 					manager.getAllPrompts(),
 				]);
 				spinner.stop();
+
+				// We already have every server's live tools — keep the search index fresh by
+				// re-indexing any server whose tools have changed since it was last indexed.
+				await refreshIndexOnDrift(config, toolsResult, formatOptions);
 
 				const items: UnifiedItem[] = [
 					...toolsResult.tools.map((t) => ({
@@ -65,4 +73,26 @@ export function registerListCommand(program: Command) {
 			},
 		),
 	);
+}
+
+/** Refresh the search index for any server whose tools have drifted since the last index. */
+async function refreshIndexOnDrift(
+	config: Config,
+	toolsResult: { tools: ToolWithServer[]; errors: ServerError[] },
+	formatOptions: FormatOptions,
+): Promise<void> {
+	const spinner = logger.startSpinner("Refreshing search index...", formatOptions);
+	try {
+		const { servers } = await maybeReindexDrift(config, toolsResult.tools, toolsResult.errors, (p) => {
+			spinner.update(`Re-indexing ${p.current}/${p.total}: ${p.tool}`);
+		});
+		spinner.stop();
+		if (servers.length > 0) {
+			logger.info(`Re-indexed tools for: ${servers.join(", ")} (changed since last index)`);
+		}
+	} catch (err) {
+		// A drift refresh is best-effort; never let it break `list` output.
+		spinner.stop();
+		logger.warn(`Could not refresh search index: ${String(err)}`);
+	}
 }

--- a/src/search/auto-reindex.ts
+++ b/src/search/auto-reindex.ts
@@ -1,0 +1,42 @@
+import type { ServerError, ToolWithServer } from "../client/manager.ts";
+import { saveSearchIndex } from "../config/loader.ts";
+import type { Config, SearchIndex } from "../config/schemas.ts";
+import { type IndexProgress, reindexServers } from "./indexer.ts";
+import { getDriftedServers, isEmbeddingModelStale } from "./staleness.ts";
+
+/**
+ * Detect tool drift against the existing search index and, if found, incrementally
+ * re-index only the drifted servers and persist the result. Mutates `config.searchIndex`
+ * in place so callers reading it afterwards see the refreshed index.
+ *
+ * No-ops (and returns no drifted servers) when:
+ *  - there is no existing index (don't silently build a full index as a side effect), or
+ *  - the index's embedding model is stale (that needs a full rebuild via `mcpx index`).
+ *
+ * Servers that failed to connect (present in `errors`) are never re-indexed or pruned.
+ */
+export async function maybeReindexDrift(
+	config: Config,
+	allLiveTools: ToolWithServer[],
+	errors: ServerError[],
+	onProgress?: (progress: IndexProgress) => void,
+): Promise<{ servers: string[]; index: SearchIndex }> {
+	const index = config.searchIndex;
+
+	if (index.tools.length === 0 || isEmbeddingModelStale(index)) {
+		return { servers: [], index };
+	}
+
+	const failed = new Set(errors.map((e) => e.server));
+	const connectedServers = Object.keys(config.servers.mcpServers).filter((s) => !failed.has(s));
+
+	const drifted = getDriftedServers(index, allLiveTools, connectedServers);
+	if (drifted.length === 0) {
+		return { servers: [], index };
+	}
+
+	const newIndex = await reindexServers(index, allLiveTools, drifted, onProgress);
+	await saveSearchIndex(config.configDir, newIndex);
+	config.searchIndex = newIndex;
+	return { servers: drifted, index: newIndex };
+}

--- a/src/search/indexer.ts
+++ b/src/search/indexer.ts
@@ -37,7 +37,7 @@ export function generateScenarios(name: string, description: string): string[] {
 }
 
 /** Build an IndexedTool from a tool with server info */
-async function indexTool(t: ToolWithServer): Promise<IndexedTool> {
+export async function indexTool(t: ToolWithServer): Promise<IndexedTool> {
 	const description = t.tool.description ?? "";
 	const keywords = extractKeywords(t.tool.name);
 	const scenarios = generateScenarios(t.tool.name, description);
@@ -89,5 +89,37 @@ export async function buildSearchIndex(
 		indexed_at: new Date().toISOString(),
 		embedding_model: EMBEDDING_MODEL.REPO,
 		tools: indexed,
+	};
+}
+
+/**
+ * Rebuild only the entries for `driftedServers`, reusing existing entries for every other server.
+ * Returns a new SearchIndex; the original is not mutated.
+ */
+export async function reindexServers(
+	index: SearchIndex,
+	allLiveTools: ToolWithServer[],
+	driftedServers: string[],
+	onProgress?: (progress: IndexProgress) => void,
+): Promise<SearchIndex> {
+	const drifted = new Set(driftedServers);
+
+	// Keep entries for servers that didn't drift.
+	const kept = index.tools.filter((t) => !drifted.has(t.server));
+
+	// Re-embed live tools for the drifted servers.
+	const toReindex = allLiveTools.filter((t) => drifted.has(t.server));
+	const reindexed: IndexedTool[] = [];
+	for (let i = 0; i < toReindex.length; i++) {
+		const t = toReindex[i]!;
+		onProgress?.({ total: toReindex.length, current: i + 1, tool: `${t.server}/${t.tool.name}` });
+		reindexed.push(await indexTool(t));
+	}
+
+	return {
+		version: index.version,
+		indexed_at: new Date().toISOString(),
+		embedding_model: EMBEDDING_MODEL.REPO,
+		tools: [...kept, ...reindexed],
 	};
 }

--- a/src/search/staleness.ts
+++ b/src/search/staleness.ts
@@ -1,3 +1,4 @@
+import type { ToolWithServer } from "../client/manager.ts";
 import type { SearchIndex, ServersFile } from "../config/schemas.ts";
 import { EMBEDDING_MODEL } from "../constants.ts";
 
@@ -11,4 +12,70 @@ export function getStaleServers(index: SearchIndex, servers: ServersFile): strin
 /** Return true if the index was built with a different embedding model than the one we'd use now. */
 export function isEmbeddingModelStale(index: SearchIndex): boolean {
 	return index.tools.length > 0 && index.embedding_model !== EMBEDDING_MODEL.REPO;
+}
+
+/** Canonical, key-sorted JSON so object key ordering doesn't register as a change. */
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+	if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+	const obj = value as Record<string, unknown>;
+	const keys = Object.keys(obj).sort();
+	return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+/** Signature of one server's tool set: a sorted, canonical encoding of name + description + schema. */
+function serverSignature(tools: { name: string; description?: string; inputSchema?: unknown }[]): string {
+	return tools
+		.map((t) => JSON.stringify([t.name, t.description ?? "", stableStringify(t.inputSchema)]))
+		.sort()
+		.join("\n");
+}
+
+/** Group an array by a key into a Map of key -> items. */
+function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {
+	const map = new Map<string, T[]>();
+	for (const item of items) {
+		const k = key(item);
+		const arr = map.get(k);
+		if (arr) arr.push(item);
+		else map.set(k, [item]);
+	}
+	return map;
+}
+
+/**
+ * Return connected servers whose live tools differ from what's in the index —
+ * i.e. tools were added, changed, or removed within a still-configured server.
+ *
+ * Only `connectedServers` (servers that returned tools without error) are considered,
+ * so a server that failed to connect is never reported as drifted. A configured server
+ * with no entries in the index yet counts as drifted ("new tools").
+ */
+export function getDriftedServers(
+	index: SearchIndex,
+	liveTools: ToolWithServer[],
+	connectedServers: string[],
+): string[] {
+	const indexedByServer = groupBy(index.tools, (t) => t.server);
+	const liveByServer = groupBy(liveTools, (t) => t.server);
+
+	const drifted: string[] = [];
+	for (const server of connectedServers) {
+		const indexedSig = serverSignature(
+			(indexedByServer.get(server) ?? []).map((t) => ({
+				name: t.tool,
+				description: t.description,
+				inputSchema: t.input_schema,
+			})),
+		);
+		const liveSig = serverSignature(
+			(liveByServer.get(server) ?? []).map((t) => ({
+				name: t.tool.name,
+				description: t.tool.description,
+				inputSchema: t.tool.inputSchema,
+			})),
+		);
+		if (indexedSig !== liveSig) drifted.push(server);
+	}
+	return drifted;
 }

--- a/test/search/staleness.test.ts
+++ b/test/search/staleness.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import type { ToolWithServer } from "../../src/client/manager.ts";
 import type { SearchIndex, ServersFile } from "../../src/config/schemas.ts";
 import { EMBEDDING_MODEL } from "../../src/constants.ts";
-import { getStaleServers, isEmbeddingModelStale } from "../../src/search/staleness.ts";
+import { getDriftedServers, getStaleServers, isEmbeddingModelStale } from "../../src/search/staleness.ts";
 
 function makeIndex(overrides: Partial<SearchIndex> = {}): SearchIndex {
 	return {
@@ -52,5 +53,92 @@ describe("isEmbeddingModelStale", () => {
 
 	test("returns false when the index has no tools, even with a different model", () => {
 		expect(isEmbeddingModelStale(makeIndex({ embedding_model: "something-else", tools: [] }))).toBe(false);
+	});
+});
+
+describe("getDriftedServers", () => {
+	function liveTool(server: string, name: string, description = "", inputSchema?: unknown): ToolWithServer {
+		return { server, tool: { name, description, inputSchema: inputSchema as ToolWithServer["tool"]["inputSchema"] } };
+	}
+
+	const index = makeIndex({
+		tools: [
+			{
+				server: "arcade",
+				tool: "Gmail_SendEmail",
+				description: "Send an email",
+				input_schema: { type: "object", properties: { to: { type: "string" } } },
+				scenarios: [],
+				keywords: [],
+				embedding: [],
+			},
+		],
+	});
+
+	test("returns empty when live tools match the index", () => {
+		const live = [
+			liveTool("arcade", "Gmail_SendEmail", "Send an email", {
+				type: "object",
+				properties: { to: { type: "string" } },
+			}),
+		];
+		expect(getDriftedServers(index, live, ["arcade"])).toEqual([]);
+	});
+
+	test("detects an added tool", () => {
+		const live = [
+			liveTool("arcade", "Gmail_SendEmail", "Send an email", {
+				type: "object",
+				properties: { to: { type: "string" } },
+			}),
+			liveTool("arcade", "Gmail_ListEmails", "List emails"),
+		];
+		expect(getDriftedServers(index, live, ["arcade"])).toEqual(["arcade"]);
+	});
+
+	test("detects a changed description", () => {
+		const live = [
+			liveTool("arcade", "Gmail_SendEmail", "Send a message", {
+				type: "object",
+				properties: { to: { type: "string" } },
+			}),
+		];
+		expect(getDriftedServers(index, live, ["arcade"])).toEqual(["arcade"]);
+	});
+
+	test("detects a changed input schema", () => {
+		const live = [
+			liveTool("arcade", "Gmail_SendEmail", "Send an email", {
+				type: "object",
+				properties: { to: { type: "string" }, cc: { type: "string" } },
+			}),
+		];
+		expect(getDriftedServers(index, live, ["arcade"])).toEqual(["arcade"]);
+	});
+
+	test("detects a tool removed from a server", () => {
+		expect(getDriftedServers(index, [], ["arcade"])).toEqual(["arcade"]);
+	});
+
+	test("ignores schema key ordering differences", () => {
+		// Same schema, keys declared in a different order — must NOT register as drift.
+		const live = [
+			liveTool("arcade", "Gmail_SendEmail", "Send an email", {
+				properties: { to: { type: "string" } },
+				type: "object",
+			}),
+		];
+		expect(getDriftedServers(index, live, ["arcade"])).toEqual([]);
+	});
+
+	test("only considers connected servers", () => {
+		// arcade drifted, but it's not in the connected list → not reported.
+		const live = [liveTool("arcade", "Gmail_SendEmail", "Changed")];
+		expect(getDriftedServers(index, live, [])).toEqual([]);
+	});
+
+	test("treats a configured server with no index entries as drifted", () => {
+		const live = [liveTool("github", "search_repos", "Search repositories")];
+		expect(getDriftedServers(index, live, ["github"])).toEqual(["github"]);
 	});
 });


### PR DESCRIPTION
The search index previously only went stale when a server was removed or the embedding model changed — it never noticed when a still-configured server added, renamed, or changed a tool. This adds per-server drift detection (`getDriftedServers` in `src/search/staleness.ts`, a key-sorted signature over tool name + description + input_schema, needing no index schema change) and an incremental `reindexServers` that re-embeds only the drifted servers via the new `maybeReindexDrift` helper. `mcpx` (the default list) and `mcpx index --status` already fetch every server's live tools, so they now detect drift and refresh just the affected servers in the background, reporting which servers changed. Servers that fail to connect are never pruned, and no index is built where none exists. Adds unit tests for the drift cases, updates the README and both skill docs, and bumps the patch version to 0.21.10.