### PR TITLE
Fix flaky embedding tests by retrying transient HF model downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,19 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bash scripts/apply-transformers-patch.sh
+      # Cache the embedding model so it's downloaded from Hugging Face once and
+      # reused across runs, avoiding the per-run 429 rate-limits that make the
+      # semantic tests flaky. Key includes the model repo + revision so a model
+      # change busts the cache.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mcpx/transformers
+          key: transformers-Xenova-bge-small-en-v1.5-main
       - run: bun lint
+      # Warm the model cache (with the in-app retry/backoff) before the test
+      # suite so a cold cache populates the cache step above instead of failing
+      # mid-test on a transient download error.
+      - run: bun -e 'await (await import("./src/search/semantic.ts")).generateEmbedding("warm")'
       - run: bun test
 
   test-upgrade:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,17 @@ jobs:
       - run: bash scripts/apply-transformers-patch.sh
       # Cache the embedding model so it's downloaded from Hugging Face once and
       # reused across runs, avoiding the per-run 429 rate-limits that make the
-      # semantic tests flaky. Key includes the model repo + revision so a model
-      # change busts the cache.
+      # semantic tests flaky. The key is hashed from src/constants.ts (which
+      # holds the model repo/revision), so changing the model re-keys the cache;
+      # restore-keys falls back to any prior transformers-* cache so we still
+      # start warm — and avoid a full re-download — even right after a model
+      # change. This caches to avoid rate limits, not to pin exact contents.
       - uses: actions/cache@v4
         with:
           path: ~/.cache/mcpx/transformers
-          key: transformers-Xenova-bge-small-en-v1.5-main
+          key: transformers-${{ hashFiles('src/constants.ts') }}
+          restore-keys: |
+            transformers-
       - run: bun lint
       # Warm the model cache (with the in-app retry/backoff) before the test
       # suite so a cold cache populates the cache step above instead of failing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.10",
+	"version": "0.21.11",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/search/semantic.ts
+++ b/src/search/semantic.ts
@@ -59,19 +59,37 @@ async function getEmbedder(): Promise<(text: string) => Promise<Float32Array>> {
 	// q8 quantization gives near-identical embedding quality at ~25% the model
 	// size (≈22 MB vs ≈86 MB for fp32). See onnx setup comment above for why
 	// we try `wasm` first and fall back to `cpu`.
+	//
+	// The first call downloads the model from Hugging Face, which can return a
+	// transient 429 (rate limit) or 5xx — retry those with exponential backoff
+	// so a flaky network doesn't fail the user's first index (or CI). The
+	// wasm→cpu device fallback ("Unsupported device") is NOT a transient error
+	// and is handled separately below.
+	const loadPipeline = () =>
+		transformers
+			.pipeline("feature-extraction", EMBEDDING_MODEL.REPO, { device: "wasm", dtype: "q8" })
+			.catch((err: unknown) => {
+				if (!String((err as Error)?.message ?? "").includes("Unsupported device")) throw err;
+				logger.debug("WASM backend unavailable; falling back to cpu (onnxruntime-node)");
+				return transformers.pipeline("feature-extraction", EMBEDDING_MODEL.REPO, { device: "cpu", dtype: "q8" });
+			});
+
 	let extractor: Awaited<ReturnType<typeof transformers.pipeline>>;
-	try {
-		extractor = await transformers.pipeline("feature-extraction", EMBEDDING_MODEL.REPO, {
-			device: "wasm",
-			dtype: "q8",
-		});
-	} catch (err) {
-		if (!String((err as Error)?.message ?? "").includes("Unsupported device")) throw err;
-		logger.debug("WASM backend unavailable; falling back to cpu (onnxruntime-node)");
-		extractor = await transformers.pipeline("feature-extraction", EMBEDDING_MODEL.REPO, {
-			device: "cpu",
-			dtype: "q8",
-		});
+	const maxAttempts = 4;
+	for (let attempt = 1; ; attempt++) {
+		try {
+			extractor = await loadPipeline();
+			break;
+		} catch (err) {
+			const message = String((err as Error)?.message ?? "");
+			const transient = /\b(429|5\d\d)\b/.test(message) || /load file/i.test(message);
+			if (!transient || attempt >= maxAttempts) throw err;
+			const delayMs = Math.round(2 ** (attempt - 1) * 500 * (1 + Math.random() * 0.25));
+			logger.warn(
+				`Failed to download embedding model (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms: ${message}`,
+			);
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
 	}
 
 	pipelineInstance = async (text: string): Promise<Float32Array> => {


### PR DESCRIPTION
## Why

[PR #93](https://github.com/evantahler/mcpx/pull/93) appeared to "merge with failing tests." It didn't — the gate works:

- The PR's `pull_request` CI run passed all checks, including the required `complete` gate, so GitHub allowed the merge.
- The **post-merge `push`-to-`main` run** then failed on 2 tests in `test/search/semantic.test.ts` with:
  ```
  Error (429) occurred while trying to load file:
  "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/config.json"
  ```

The `generateEmbedding` tests download the real embedding model from Hugging Face at test time. CI has no model cache, so every run re-downloads, and HF periodically **rate-limits (429)**. The PR run got lucky; the push run didn't. The tests are flaky, not the merge gate.

## What

- **`src/search/semantic.ts`** — retry the model load with exponential backoff on transient download errors (429 / 5xx / "load file"), preserving the existing wasm→cpu device fallback. This also helps real users, who hit the same 429s on their first index.
- **`.github/workflows/ci.yml`** — cache `~/.cache/mcpx/transformers` (keyed on model repo + revision) so the model downloads once and is reused across runs, and pre-warm the cache before `bun test` so a cold cache populates outside the test suite.

Branch protection is intentionally left as-is — the required `complete` check already blocks merges when tests fail. Making the tests deterministic is what actually keeps a green PR green on `main`.

## Verification

- `bun test` — 451 pass locally (run repeatedly).
- `bun lint` — clean.
- Confirmed the transient-error regex matches the real 429 message and ignores the `Unsupported device` fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)