### PR TITLE
Add SDK human-in-the-loop approval gate and expose tool annotations

### DIFF
--- a/.claude/skills/mcpx.md
+++ b/.claude/skills/mcpx.md
@@ -143,7 +143,7 @@ mcpx deauth <server>           # remove stored auth
 | `mcpx servers`                        | List servers (name, type, detail) |
 | `mcpx -d`                             | List with descriptions            |
 | `mcpx info <server>`                  | Server overview (version, capabilities, tools) |
-| `mcpx info <server> <tool>`           | Show tool schema                  |
+| `mcpx info <server> <tool>`           | Show tool schema + annotations    |
 | `mcpx exec <server>`                  | List tools for a server           |
 | `mcpx exec <tool> '<json>'`           | Execute tool (server auto-resolved) |
 | `mcpx exec <server> <tool> '<json>'`  | Execute tool (explicit server)    |

--- a/.cursor/rules/mcpx.mdc
+++ b/.cursor/rules/mcpx.mdc
@@ -139,7 +139,7 @@ mcpx deauth <server>           # remove stored auth
 | `mcpx servers`                        | List servers (name, type, detail) |
 | `mcpx -d`                             | List with descriptions            |
 | `mcpx info <server>`                  | Server overview (version, capabilities, tools) |
-| `mcpx info <server> <tool>`           | Show tool schema                  |
+| `mcpx info <server> <tool>`           | Show tool schema + annotations    |
 | `mcpx exec <server>`                  | List tools for a server           |
 | `mcpx exec <tool> '<json>'`           | Execute tool (server auto-resolved) |
 | `mcpx exec <server> <tool> '<json>'`  | Execute tool (explicit server)    |

--- a/README.md
+++ b/README.md
@@ -737,6 +737,77 @@ const client = new McpxClient({
 });
 ```
 
+#### Tool metadata
+
+`info()` and `listTools()` return the raw MCP `Tool`, so you get everything the server declares: `name`, `title`, `description`, `inputSchema`, `outputSchema`, `execution.taskSupport`, and `annotations`. The `annotations` object carries the MCP behavioral hints:
+
+```typescript
+const tool = await client.info("github", "delete_repo");
+tool?.annotations; // { title?, readOnlyHint?, destructiveHint?, idempotentHint?, openWorldHint? }
+```
+
+> ⚠️ Annotations are **untrusted hints** — per the MCP spec, clients should never make tool-use decisions based on annotations from untrusted servers. Treat the approval gate below as a guardrail, not a security boundary.
+
+#### Human-in-the-loop approval gate
+
+Because the SDK runs non-interactively, mcpx can't prompt a human itself — instead you supply an approval callback and a policy for which tools to gate. This lets you require approval before, say, any **open-world writeable** tool (`openWorldHint: true` and not `readOnlyHint`) runs:
+
+```typescript
+import { McpxClient, ToolApprovalDeniedError } from "@evantahler/mcpx";
+
+const client = new McpxClient({
+  servers: { mcpServers: { github: { url: "https://mcp.github.com" } } },
+  approvalPolicy: "open-world-writeable", // default is "none"
+  onApprovalRequired: async ({ server, tool, args, annotations, reason }) => {
+    // Prompt a human, call out to an approval service, check a policy, etc.
+    return await promptHuman(`Allow ${server}/${tool}? (${reason})`, args);
+  },
+});
+
+// Gated tools wait for the callback; returning false throws ToolApprovalDeniedError.
+// If a tool is gated but no onApprovalRequired callback was provided, exec() throws
+// ToolApprovalRequiredError (fail-closed).
+await client.exec("github", "delete_repo", { repo: "old-thing" });
+```
+
+`approvalPolicy` accepts:
+
+| Value                   | Gates                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| `"none"` _(default)_    | nothing — existing behavior, zero overhead                                         |
+| `"open-world-writeable"`| tools with `openWorldHint: true` and not `readOnlyHint` (unannotated tools pass)   |
+| `"writeable"`           | any tool not explicitly `readOnlyHint: true` (also gates unannotated tools)        |
+| `"all"`                 | every `exec()` call                                                                |
+| `(tool, server) => boolean` | a custom predicate                                                             |
+| `Array<…>`              | any of the above, combined with OR                                                 |
+
+Helpers `isOpenWorldWriteable(tool)` and `isWriteable(tool)` are exported for building custom predicates, along with the `ToolAnnotations` type. `mcpx info <server> <tool>` also surfaces these hints in the CLI.
+
+**Gating a specific tool by name.** The annotation presets can't tell two similar tools apart — a "create PR" and a "create issue" tool both look like open-world writes. To gate one but not the other, use the custom predicate form and match on `tool.name` (and `server`):
+
+```typescript
+const client = new McpxClient({
+  servers: { mcpServers: { github: { url: "https://mcp.github.com" } } },
+
+  // Require approval ONLY for creating PRs — issue creation runs freely.
+  approvalPolicy: (tool, server) => server === "github" && tool.name === "create_pull_request",
+
+  onApprovalRequired: async ({ server, tool, args }) => await promptHuman(`Allow ${server}/${tool}?`, args),
+});
+
+await client.exec("github", "create_pull_request", { ... }); // waits for approval
+await client.exec("github", "create_issue", { ... }); // runs immediately, no prompt
+```
+
+Confirm the exact `tool.name` first — it must match exactly, and servers name tools differently (e.g. `create_pull_request` vs `github_create_pr`):
+
+```bash
+mcpx search "open pull request"      # find the tool and its server
+mcpx info github create_pull_request # confirm the name
+```
+
+To match a family of tools, use a regex (`/pull_request|merge_pr/.test(tool.name)`); to gate the PR tool _and_ everything open-world-writeable, combine them with the array form: `["open-world-writeable", (tool, server) => …]`. Matching on `tool.name` is reliable — unlike `annotations`, which are untrusted server-supplied hints.
+
 ## Permissions (Claude Code & Cursor)
 
 AI agents like Claude Code and Cursor prompt users to approve each `mcpx exec` call. `mcpx allow` and `mcpx deny` manage fine-grained permission rules so agents can self-authorize specific tools without broad access.

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "mcpcli",
+      "name": "@evantahler/mcpx",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evantahler/mcpx",
-	"version": "0.21.11",
+	"version": "0.22.2",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -251,6 +251,7 @@ export function formatToolSchema(serverName: string, tool: Tool, options: Format
 			tool: tool.name,
 			description: tool.description ?? "",
 			inputSchema: tool.inputSchema,
+			annotations: tool.annotations,
 		},
 		() => {
 			const lines: string[] = [];
@@ -258,6 +259,12 @@ export function formatToolSchema(serverName: string, tool: Tool, options: Format
 			lines.push(`${theme.path(serverName)}/${theme.tool(tool.name)}`);
 			lines.push(underline(headerText.length));
 			if (tool.description) lines.push(theme.muted(tool.description));
+			const annotations = formatAnnotations(tool.annotations);
+			if (annotations) {
+				lines.push("");
+				lines.push(theme.tool("Annotations:"));
+				lines.push(`  ${annotations}`);
+			}
 			lines.push("");
 			lines.push(theme.tool("Input Schema:"));
 			lines.push(formatSchema(tool.inputSchema, 2));
@@ -265,6 +272,40 @@ export function formatToolSchema(serverName: string, tool: Tool, options: Format
 		},
 		options,
 	);
+}
+
+/**
+ * Display labels for each MCP `ToolAnnotations` hint, keyed by its `true`/`false`
+ * value. MCP models these hints as booleans (not enums), so the human-readable
+ * strings live here. The keys are type-checked against the SDK's annotation
+ * type — renaming or removing a hint upstream becomes a compile error rather
+ * than silently dropping a label.
+ */
+const ANNOTATION_LABELS: {
+	[K in keyof NonNullable<Tool["annotations"]>]?: { true?: string; false?: string };
+} = {
+	readOnlyHint: { true: "read-only", false: "writeable" },
+	destructiveHint: { true: "destructive" },
+	idempotentHint: { true: "idempotent" },
+	openWorldHint: { true: "open-world", false: "closed-world" },
+};
+
+/**
+ * Format a tool's MCP annotation hints as a compact comma-separated list.
+ * Returns undefined when no annotation hints are set. Note: annotations are
+ * untrusted hints, not a behavioral guarantee.
+ */
+function formatAnnotations(annotations: Tool["annotations"]): string | undefined {
+	if (!annotations) return undefined;
+	const labels: string[] = [];
+	for (const key of Object.keys(ANNOTATION_LABELS) as (keyof typeof ANNOTATION_LABELS)[]) {
+		const variants = ANNOTATION_LABELS[key];
+		const value = annotations[key];
+		if (value === true && variants?.true) labels.push(variants.true);
+		else if (value === false && variants?.false) labels.push(variants.false);
+	}
+	if (labels.length === 0) return undefined;
+	return theme.muted(labels.join(", "));
 }
 
 /** Format a JSON schema as a readable parameter list */

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,6 +3,7 @@ import type {
 	CancelTaskResult,
 	GetTaskResult,
 	ListTasksResult,
+	ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import type {
 	PromptWithServer,
@@ -58,12 +59,120 @@ export type {
 	StdioServerConfig,
 	// Config types
 	Tool,
+	// MCP tool annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint, title)
+	ToolAnnotations,
 	// Manager types
 	ToolWithServer,
 	ValidationError,
 	// Validation types
 	ValidationResult,
 };
+
+// ---------------------------------------------------------------------------
+// Human-in-the-loop approval gate
+//
+// MCP tools carry optional `annotations` (readOnlyHint, destructiveHint,
+// idempotentHint, openWorldHint). SDK consumers can require a human/approval
+// callback before executing tools that match a policy — e.g. "open-world
+// writeable" tools. Per the MCP spec these annotations are *untrusted hints*:
+// "Clients should never make tool use decisions based on ToolAnnotations
+// received from untrusted servers." Treat this gate as a guardrail, not a
+// security boundary.
+// ---------------------------------------------------------------------------
+
+/** Built-in classification presets for which tools require approval. */
+export type ApprovalPolicyPreset =
+	| "none" // default — nothing is gated (back-compat)
+	| "open-world-writeable" // openWorldHint === true AND readOnlyHint !== true
+	| "writeable" // readOnlyHint !== true (also gates unannotated tools)
+	| "all"; // every exec is gated
+
+/**
+ * Custom classifier. Return true to require approval for this tool.
+ * `tool` is the raw MCP Tool (its `annotations` may be undefined).
+ */
+export type ApprovalPredicate = (tool: Tool, server: string) => boolean;
+
+/** A preset, a custom predicate, or an array of either combined with OR. */
+export type ApprovalPolicy = ApprovalPolicyPreset | ApprovalPredicate | Array<ApprovalPolicyPreset | ApprovalPredicate>;
+
+/** Passed to the approval callback describing the pending tool call. */
+export interface ToolApprovalRequest {
+	server: string;
+	tool: string;
+	/** Arguments exec() was called with (after defaulting to {}). */
+	args: Record<string, unknown>;
+	/** The full resolved Tool schema, including annotations. */
+	schema: Tool;
+	/** Convenience accessor for schema.annotations (may be undefined). */
+	annotations: ToolAnnotations | undefined;
+	/** Which preset/predicate flagged this call, for logging. */
+	reason: string;
+}
+
+/** Approval callback. Return true to allow, false to deny. May be async. */
+export type ToolApprovalCallback = (request: ToolApprovalRequest) => boolean | Promise<boolean>;
+
+/** Thrown when a tool is gated but no onApprovalRequired callback was supplied. */
+export class ToolApprovalRequiredError extends Error {
+	readonly server: string;
+	readonly tool: string;
+	constructor(server: string, tool: string) {
+		super(
+			`Tool "${server}/${tool}" requires human approval, but no onApprovalRequired callback was provided. ` +
+				`Supply McpxClientOptions.onApprovalRequired, or set approvalPolicy to "none".`,
+		);
+		this.name = "ToolApprovalRequiredError";
+		this.server = server;
+		this.tool = tool;
+	}
+}
+
+/** Thrown when the approval callback denies a gated tool call. */
+export class ToolApprovalDeniedError extends Error {
+	readonly server: string;
+	readonly tool: string;
+	constructor(server: string, tool: string) {
+		super(`Execution of "${server}/${tool}" was denied by the approval callback.`);
+		this.name = "ToolApprovalDeniedError";
+		this.server = server;
+		this.tool = tool;
+	}
+}
+
+/**
+ * True when a tool is annotated as interacting with an "open world" of external
+ * entities AND is not marked read-only. Fail-permissive: tools with no
+ * `openWorldHint` are NOT considered open-world (absence of a hint is not an
+ * affirmative mark).
+ */
+export function isOpenWorldWriteable(tool: Tool): boolean {
+	const a = tool.annotations;
+	return a?.openWorldHint === true && a?.readOnlyHint !== true;
+}
+
+/**
+ * True when a tool is not explicitly marked read-only. Fail-safe: tools with no
+ * annotations ARE considered writeable.
+ */
+export function isWriteable(tool: Tool): boolean {
+	return tool.annotations?.readOnlyHint !== true;
+}
+
+/** Resolve a single preset/predicate into a matcher with a human-readable reason label. */
+function presetMatcher(p: ApprovalPolicyPreset | ApprovalPredicate): { reason: string; match: ApprovalPredicate } {
+	if (typeof p === "function") return { reason: "custom-predicate", match: p };
+	switch (p) {
+		case "open-world-writeable":
+			return { reason: "open-world-writeable", match: isOpenWorldWriteable };
+		case "writeable":
+			return { reason: "writeable", match: isWriteable };
+		case "all":
+			return { reason: "all", match: () => true };
+		default:
+			return { reason: "none", match: () => false };
+	}
+}
 
 export interface McpxClientOptions {
 	/** Path to config directory. Defaults to ~/.mcpx or MCP_CONFIG_PATH env var. */
@@ -82,6 +191,18 @@ export interface McpxClientOptions {
 	maxRetries?: number;
 	/** Enable verbose/trace logging. Default: false */
 	verbose?: boolean;
+	/**
+	 * Which tools require human approval before exec(). Default: "none".
+	 * A preset string, a custom predicate, or an array of either (OR-combined).
+	 */
+	approvalPolicy?: ApprovalPolicy;
+	/**
+	 * Async callback invoked when a gated tool is about to run. Return false to
+	 * deny (exec() throws ToolApprovalDeniedError). Required whenever
+	 * approvalPolicy gates anything — if a gated tool is reached without a
+	 * callback, exec() throws ToolApprovalRequiredError.
+	 */
+	onApprovalRequired?: ToolApprovalCallback;
 }
 
 export class McpxClient {
@@ -170,7 +291,56 @@ export class McpxClient {
 	/** Execute a tool and return the result. */
 	async exec(server: string, tool: string, args?: Record<string, unknown>): Promise<CallToolResult> {
 		const manager = await this.ensureConnected();
-		return manager.callTool(server, tool, args ?? {}) as Promise<CallToolResult>;
+		const callArgs = args ?? {};
+
+		// Fast path: when no approval policy can gate anything, run the tool
+		// directly — no extra schema fetch, identical to pre-gate behavior.
+		if (!this.isApprovalActive()) {
+			return manager.callTool(server, tool, callArgs) as Promise<CallToolResult>;
+		}
+
+		// Policy is active — resolve the schema once to classify the tool.
+		const schema = await manager.getToolSchema(server, tool);
+		// Unknown tool: defer to callTool so the canonical error surfaces (don't mask it).
+		if (schema) {
+			const reason = this.classify(schema, server);
+			if (reason) {
+				if (!this.options.onApprovalRequired) {
+					throw new ToolApprovalRequiredError(server, tool);
+				}
+				const approved = await this.options.onApprovalRequired({
+					server,
+					tool,
+					args: callArgs,
+					schema,
+					annotations: schema.annotations,
+					reason,
+				});
+				if (!approved) throw new ToolApprovalDeniedError(server, tool);
+			}
+		}
+
+		return manager.callTool(server, tool, callArgs) as Promise<CallToolResult>;
+	}
+
+	/** True when approvalPolicy could gate at least one tool. */
+	private isApprovalActive(): boolean {
+		const policy = this.options.approvalPolicy;
+		if (policy === undefined) return false;
+		const entries = Array.isArray(policy) ? policy : [policy];
+		return entries.some((p) => p !== "none");
+	}
+
+	/** Classify a tool against the policy. Returns the matching reason, or undefined if not gated. */
+	private classify(tool: Tool, server: string): string | undefined {
+		const policy = this.options.approvalPolicy;
+		if (policy === undefined) return undefined;
+		const entries = Array.isArray(policy) ? policy : [policy];
+		for (const entry of entries) {
+			const { reason, match } = presetMatcher(entry);
+			if (match(tool, server)) return reason;
+		}
+		return undefined;
 	}
 
 	// ---------------------------------------------------------------------------

--- a/test/fixtures/mock-server.ts
+++ b/test/fixtures/mock-server.ts
@@ -194,6 +194,24 @@ function handleMessage(line: string) {
 						required: ["action"],
 					},
 				},
+				{
+					name: "delete_world",
+					description: "An open-world writeable tool (annotated)",
+					inputSchema: {
+						type: "object",
+						properties: {
+							target: { type: "string", description: "What to delete" },
+						},
+						required: ["target"],
+					},
+					annotations: { openWorldHint: true, readOnlyHint: false, destructiveHint: true },
+				},
+				{
+					name: "read_status",
+					description: "A read-only tool (annotated)",
+					inputSchema: { type: "object", properties: {} },
+					annotations: { readOnlyHint: true, openWorldHint: true },
+				},
 			],
 		});
 	} else if (msg.method === "logging/setLevel") {
@@ -255,6 +273,14 @@ function handleMessage(line: string) {
 			// Send an elicitation request to the client, wait for response, then reply
 			handleConfirmAction(msg.id!, String(params.arguments?.action ?? "unknown"));
 			return; // async — respond later
+		} else if (params.name === "delete_world") {
+			respond(msg.id, {
+				content: [{ type: "text", text: `deleted ${String(params.arguments?.target ?? "")}` }],
+			});
+		} else if (params.name === "read_status") {
+			respond(msg.id, {
+				content: [{ type: "text", text: "ok" }],
+			});
 		} else if (params.name === "noop") {
 			respond(msg.id, {
 				content: [{ type: "text", text: "ok" }],

--- a/test/integration/stdio-server.test.ts
+++ b/test/integration/stdio-server.test.ts
@@ -37,7 +37,7 @@ describe("stdio MCP server integration", () => {
 		const resources = items.filter((i) => i.type === "resource");
 		const prompts = items.filter((i) => i.type === "prompt");
 
-		expect(tools.length).toBe(6);
+		expect(tools.length).toBe(8);
 		expect(resources.length).toBeGreaterThan(0);
 		expect(prompts.length).toBeGreaterThan(0);
 
@@ -48,6 +48,8 @@ describe("stdio MCP server integration", () => {
 		expect(toolNames).toContain("noop");
 		expect(toolNames).toContain("slow_echo");
 		expect(toolNames).toContain("confirm_action");
+		expect(toolNames).toContain("delete_world");
+		expect(toolNames).toContain("read_status");
 
 		// Every item should be from the "mock" server
 		for (const item of items) {
@@ -65,7 +67,7 @@ describe("stdio MCP server integration", () => {
 	test("inspects a specific server to list its tools", async () => {
 		const result = await runAndParse<{ server: string; tools: { name: string }[] }>("info", "mock");
 		expect(result.server).toBe("mock");
-		expect(result.tools.length).toBe(6);
+		expect(result.tools.length).toBe(8);
 	});
 
 	test("inspects a specific tool to show its schema", async () => {
@@ -77,6 +79,17 @@ describe("stdio MCP server integration", () => {
 		expect(result.server).toBe("mock");
 		expect(result.tool).toBe("echo");
 		expect(result.inputSchema.properties).toHaveProperty("message");
+	});
+
+	test("exposes tool annotations in info output", async () => {
+		const result = await runAndParse<{
+			tool: string;
+			annotations?: { openWorldHint?: boolean; readOnlyHint?: boolean; destructiveHint?: boolean };
+		}>("info", "mock", "delete_world");
+		expect(result.tool).toBe("delete_world");
+		expect(result.annotations?.openWorldHint).toBe(true);
+		expect(result.annotations?.readOnlyHint).toBe(false);
+		expect(result.annotations?.destructiveHint).toBe(true);
 	});
 
 	test("calls echo tool and gets response", async () => {

--- a/test/sdk/client.test.ts
+++ b/test/sdk/client.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { join } from "node:path";
-import type { SearchIndex, ServersFile } from "../../src/sdk.ts";
-import { McpxClient } from "../../src/sdk.ts";
+import type { SearchIndex, ServersFile, Tool } from "../../src/sdk.ts";
+import {
+	isOpenWorldWriteable,
+	isWriteable,
+	McpxClient,
+	ToolApprovalDeniedError,
+	ToolApprovalRequiredError,
+} from "../../src/sdk.ts";
 import * as semanticModule from "../../src/search/semantic.ts";
 
 // Snapshot the real exports BEFORE any test mocks the module. `import * as`
@@ -448,5 +454,184 @@ describe("McpxClient", () => {
 	test("throws on unknown server", async () => {
 		client = new McpxClient({ servers: makeInlineServers() });
 		await expect(client.exec("nonexistent", "echo", {})).rejects.toThrow("Unknown server");
+	});
+
+	// ---------------------------------------------------------------------------
+	// Approval gate (human-in-the-loop)
+	// ---------------------------------------------------------------------------
+
+	describe("approval gate", () => {
+		test("no policy: callback is never invoked and exec runs (back-compat)", async () => {
+			const onApprovalRequired = mock(() => true);
+			client = new McpxClient({ servers: makeInlineServers(), onApprovalRequired });
+			const result = await client.exec("mock", "delete_world", { target: "x" });
+			const text = (result.content as { text: string }[])[0]!;
+			expect(text.text).toBe("deleted x");
+			expect(onApprovalRequired).not.toHaveBeenCalled();
+		});
+
+		test('"none" policy: callback is never invoked', async () => {
+			const onApprovalRequired = mock(() => true);
+			client = new McpxClient({ servers: makeInlineServers(), approvalPolicy: "none", onApprovalRequired });
+			await client.exec("mock", "delete_world", { target: "x" });
+			expect(onApprovalRequired).not.toHaveBeenCalled();
+		});
+
+		test("gated tool with approval granted runs", async () => {
+			const onApprovalRequired = mock(() => true);
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: "open-world-writeable",
+				onApprovalRequired,
+			});
+			const result = await client.exec("mock", "delete_world", { target: "moon" });
+			const text = (result.content as { text: string }[])[0]!;
+			expect(text.text).toBe("deleted moon");
+			expect(onApprovalRequired).toHaveBeenCalledTimes(1);
+		});
+
+		test("gated tool denied throws ToolApprovalDeniedError", async () => {
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: "open-world-writeable",
+				onApprovalRequired: () => false,
+			});
+			await expect(client.exec("mock", "delete_world", { target: "x" })).rejects.toThrow(ToolApprovalDeniedError);
+		});
+
+		test("gated tool without callback fails closed with ToolApprovalRequiredError", async () => {
+			client = new McpxClient({ servers: makeInlineServers(), approvalPolicy: "open-world-writeable" });
+			const promise = client.exec("mock", "delete_world", { target: "x" });
+			await expect(promise).rejects.toThrow(ToolApprovalRequiredError);
+			await expect(promise).rejects.toThrow("mock/delete_world");
+		});
+
+		test("read-only tool is not gated under open-world-writeable", async () => {
+			const onApprovalRequired = mock(() => true);
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: "open-world-writeable",
+				onApprovalRequired,
+			});
+			await client.exec("mock", "read_status");
+			expect(onApprovalRequired).not.toHaveBeenCalled();
+		});
+
+		test("async callback is awaited", async () => {
+			let resolved = false;
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: "open-world-writeable",
+				onApprovalRequired: async () => {
+					await new Promise((r) => setTimeout(r, 5));
+					resolved = true;
+					return true;
+				},
+			});
+			await client.exec("mock", "delete_world", { target: "x" });
+			expect(resolved).toBe(true);
+		});
+
+		test("approval request carries server, tool, args, schema, annotations, reason", async () => {
+			let captured: Record<string, unknown> | undefined;
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: "open-world-writeable",
+				onApprovalRequired: (req) => {
+					captured = req as unknown as Record<string, unknown>;
+					return true;
+				},
+			});
+			await client.exec("mock", "delete_world", { target: "earth" });
+			expect(captured?.server).toBe("mock");
+			expect(captured?.tool).toBe("delete_world");
+			expect(captured?.args).toEqual({ target: "earth" });
+			expect((captured?.schema as Tool).name).toBe("delete_world");
+			expect((captured?.annotations as { openWorldHint?: boolean }).openWorldHint).toBe(true);
+			expect(captured?.reason).toBe("open-world-writeable");
+		});
+
+		test('"open-world-writeable" does NOT gate an unannotated tool', async () => {
+			const onApprovalRequired = mock(() => true);
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: "open-world-writeable",
+				onApprovalRequired,
+			});
+			await client.exec("mock", "echo", { message: "hi" });
+			expect(onApprovalRequired).not.toHaveBeenCalled();
+		});
+
+		test('"writeable" DOES gate an unannotated tool (fail-safe)', async () => {
+			const onApprovalRequired = mock(() => true);
+			client = new McpxClient({ servers: makeInlineServers(), approvalPolicy: "writeable", onApprovalRequired });
+			await client.exec("mock", "echo", { message: "hi" });
+			expect(onApprovalRequired).toHaveBeenCalledTimes(1);
+		});
+
+		test("custom predicate gates only matching tools", async () => {
+			const onApprovalRequired = mock(() => true);
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: (tool) => tool.name === "add",
+				onApprovalRequired,
+			});
+			await client.exec("mock", "echo", { message: "hi" });
+			expect(onApprovalRequired).not.toHaveBeenCalled();
+			await client.exec("mock", "add", { a: 1, b: 2 });
+			expect(onApprovalRequired).toHaveBeenCalledTimes(1);
+		});
+
+		test("array policy combines presets and predicates with OR", async () => {
+			const onApprovalRequired = mock(() => true);
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: ["open-world-writeable", (tool) => tool.name === "add"],
+				onApprovalRequired,
+			});
+			await client.exec("mock", "delete_world", { target: "x" }); // open-world
+			await client.exec("mock", "add", { a: 1, b: 2 }); // predicate
+			expect(onApprovalRequired).toHaveBeenCalledTimes(2);
+		});
+
+		test("unknown tool under active policy still surfaces canonical error", async () => {
+			client = new McpxClient({
+				servers: makeInlineServers(),
+				approvalPolicy: "all",
+				onApprovalRequired: () => true,
+			});
+			const result = await client.exec("mock", "nonexistent", {});
+			// mock server returns an isError result for unknown tools rather than throwing
+			expect((result as { isError?: boolean }).isError).toBe(true);
+		});
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Classification helpers (pure)
+// -----------------------------------------------------------------------------
+
+describe("approval classification helpers", () => {
+	const make = (annotations?: Tool["annotations"]): Tool => ({
+		name: "t",
+		inputSchema: { type: "object" },
+		annotations,
+	});
+
+	test("isOpenWorldWriteable: open-world + not read-only", () => {
+		expect(isOpenWorldWriteable(make({ openWorldHint: true, readOnlyHint: false }))).toBe(true);
+		expect(isOpenWorldWriteable(make({ openWorldHint: true }))).toBe(true);
+	});
+
+	test("isOpenWorldWriteable: false when read-only or closed-world or unannotated", () => {
+		expect(isOpenWorldWriteable(make({ openWorldHint: true, readOnlyHint: true }))).toBe(false);
+		expect(isOpenWorldWriteable(make({ openWorldHint: false }))).toBe(false);
+		expect(isOpenWorldWriteable(make(undefined))).toBe(false);
+	});
+
+	test("isWriteable: true unless explicitly read-only", () => {
+		expect(isWriteable(make(undefined))).toBe(true);
+		expect(isWriteable(make({ readOnlyHint: false }))).toBe(true);
+		expect(isWriteable(make({ readOnlyHint: true }))).toBe(false);
 	});
 });


### PR DESCRIPTION
Surfaces MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to SDK consumers and in `mcpx info` output. Adds an opt-in human-in-the-loop approval gate to `McpxClient.exec()`: an `approvalPolicy` (presets `open-world-writeable`/`writeable`/`all`, a custom `(tool, server) => boolean` predicate, or an OR-array) selects which tools require an `onApprovalRequired` callback before running, with fail-closed errors (`ToolApprovalRequiredError`/`ToolApprovalDeniedError`) when a gated tool runs without approval. The default policy is `none`, so existing consumers are unaffected and the gated path adds zero overhead. Exports the `isOpenWorldWriteable`/`isWriteable` helpers and `ToolAnnotations` type, and documents the feature in the README (including gating a specific tool by name). Includes mock-server fixtures, an SDK approval-gate test suite, and an `info` annotations integration test.