### PR TITLE
Bump version to 1.0.1 to test publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@arcadeai/mcpx",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A command-line interface for MCP servers. curl for MCP.",
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Bumps the patch version to `1.0.1` to exercise the publishing pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)